### PR TITLE
chore: move Emulicious to ~/.local/share/emulicious/

### DIFF
--- a/.claude/skills/emulicious-debug/SKILL.md
+++ b/.claude/skills/emulicious-debug/SKILL.md
@@ -9,7 +9,7 @@ description: Use when debugging the Wasteland Racer ROM in Emulicious — EMU_pr
 
 ```sh
 # Run ROM in Emulicious
-java -jar /home/mathdaman/dev-tools/emulicious/Emulicious.jar build/wasteland-racer.gb
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
 ```
 
 **Further reading:**
@@ -53,7 +53,7 @@ EMU_printf("cam_y=%u py=%u\n", cam_y, py);
 
 1. Install "Emulicious Debugger" extension in VS Code (Ctrl+Shift+X → search "Emulicious Debugger")
 2. In VS Code preferences, set the Emulicious executable path to:
-   `/home/mathdaman/dev-tools/emulicious/Emulicious.jar`
+   `/home/mathdaman/.local/share/emulicious/Emulicious.jar`
 3. Create `.vscode/launch.json`:
 
 ```json
@@ -150,7 +150,7 @@ romusage build/wasteland-racer.cdb -a
 ## Workflow: Debugging a Bug
 
 1. Add `EMU_printf` at the suspect location, rebuild (`/build`)
-2. Launch: `java -jar /home/mathdaman/dev-tools/emulicious/Emulicious.jar build/wasteland-racer.gb`
+2. Launch: `java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb`
 3. Observe console output; narrow the problem
 4. Set VS Code breakpoints at suspect line; use Step Over/Into to inspect variables
 5. Use Tilemap/Sprite Viewers to confirm visual state matches logic

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ GBDK_HOME=/home/mathdaman/gbdk make
 make clean
 
 # Run in emulator
-java -jar /home/mathdaman/dev-tools/emulicious/Emulicious.jar build/wasteland-racer.gb
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
 ```
 
 Output ROM: `build/wasteland-racer.gb`
@@ -85,5 +85,5 @@ This project uses [Superpowers](https://github.com/obra/superpowers) (installed 
 **Build verification:** `GBDK_HOME=/home/mathdaman/gbdk make` (use `/build` skill)
 **PRDs & design docs:** GitHub issues only — no local files. Use `/prd` skill.
 
-**Smoketest gate:** NEVER commit or create a PR before the user has confirmed a smoketest in the emulator (`java -jar /home/mathdaman/dev-tools/emulicious/Emulicious.jar build/wasteland-racer.gb`). Always ask and wait for confirmation.
+**Smoketest gate:** NEVER commit or create a PR before the user has confirmed a smoketest in the emulator (`java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb`). Always ask and wait for confirmation.
 **Branch policy:** NEVER commit directly to `master`. All work goes on a feature branch and merges via PR.


### PR DESCRIPTION
## Summary
- Moves Emulicious from `~/dev-tools/emulicious/` to `~/.local/share/emulicious/` (XDG standard location for user-installed apps)
- Updates all path references in `CLAUDE.md` and `.claude/skills/emulicious-debug/SKILL.md`

Stacks on top of #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)