### PR TITLE
feat: state manager module with push/pop/replace stack

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1,20 +1,8 @@
 #include <gb/gb.h>
 #include <gb/cgb.h>
-#include <gbdk/console.h>
-#include <stdio.h>
 #include "player.h"
-#include "track.h"
-#include "camera.h"
-#include "debug.h"
-
-typedef enum {
-    STATE_INIT,
-    STATE_TITLE,
-    STATE_PLAYING,
-    STATE_GAME_OVER
-} GameState;
-
-static GameState state = STATE_INIT;
+#include "state_manager.h"
+#include "state_title.h"
 
 static const uint16_t bkg_pal[] = {
     RGB(31, 31, 31),
@@ -36,15 +24,6 @@ static void init_palettes(void) {
     }
 }
 
-static void show_title(void) {
-    cls();
-    gotoxy(2, 6);
-    printf("WASTELAND RACER");
-    gotoxy(3, 10);
-    printf("Press START");
-    state = STATE_TITLE;
-}
-
 void main(void) {
     DISPLAY_OFF;
 
@@ -53,52 +32,11 @@ void main(void) {
 
     DISPLAY_ON;
 
-    show_title();
-
-#ifdef DEBUG
-    static uint16_t frame_count = 0u;
-#endif
+    state_manager_init();
+    state_push(&state_title);
 
     while (1) {
         wait_vbl_done();
-
-        switch (state) {
-            case STATE_TITLE:
-                if (joypad() & J_START) {
-                    DISPLAY_OFF;
-                    track_init();
-                    camera_init(player_get_x(), player_get_y());
-                    DISPLAY_ON;
-                    state = STATE_PLAYING;
-                }
-                break;
-
-            case STATE_PLAYING:
-#ifdef DEBUG
-                frame_count++;
-                if (frame_count % 60u == 0u) {
-                    DBG_INT("frame", (int)frame_count);
-                    DBG_INT("px", (int)player_get_x());
-                    DBG_INT("py", (int)player_get_y());
-                }
-#endif
-                /* VBlank phase: all VRAM writes immediately after wait_vbl_done() */
-                player_render();
-                camera_flush_vram();
-                /* SCY is 8-bit and wraps at 256. Truncation is correct: stream_row() places
-                 * world row ty at VRAM row (ty & 31), so (uint8_t)cam_y correctly indexes
-                 * the ring buffer. */
-                move_bkg(0u, (uint8_t)cam_y);
-                /* Game logic phase: runs during active display */
-                player_update(joypad());
-                camera_update(player_get_x(), player_get_y());
-                break;
-
-            case STATE_GAME_OVER:
-                break;
-
-            default:
-                break;
-        }
+        state_manager_update(joypad());
     }
 }

--- a/src/state_manager.c
+++ b/src/state_manager.c
@@ -1,0 +1,41 @@
+#include "state_manager.h"
+
+#define STACK_MAX 2
+
+static const State *stack[STACK_MAX];
+static uint8_t depth = 0;
+
+void state_manager_init(void) {
+    depth = 0;
+}
+
+void state_manager_update(uint8_t input) {
+    if (depth == 0) return;
+    stack[depth - 1]->update(input);
+}
+
+void state_push(const State *s) {
+    if (depth >= STACK_MAX) return;
+    stack[depth++] = s;
+    s->enter();
+}
+
+void state_pop(void) {
+    if (depth == 0) return;
+    stack[depth - 1]->exit();
+    depth--;
+    if (depth > 0) {
+        stack[depth - 1]->enter();
+    }
+}
+
+void state_replace(const State *s) {
+    if (depth == 0) {
+        stack[depth++] = s;
+        s->enter();
+        return;
+    }
+    stack[depth - 1]->exit();
+    stack[depth - 1] = s;
+    s->enter();
+}

--- a/src/state_manager.h
+++ b/src/state_manager.h
@@ -1,0 +1,19 @@
+#ifndef STATE_MANAGER_H
+#define STATE_MANAGER_H
+
+#include <stdint.h>
+
+typedef struct {
+    void (*enter)(void);
+    void (*update)(uint8_t input);
+    void (*exit)(void);
+} State;
+
+void state_manager_init(void);
+void state_manager_update(uint8_t input);
+
+void state_push(const State *s);
+void state_pop(void);
+void state_replace(const State *s);
+
+#endif

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -1,0 +1,44 @@
+#include <gb/gb.h>
+#include "state_manager.h"
+#include "state_playing.h"
+#include "player.h"
+#include "track.h"
+#include "camera.h"
+#include "debug.h"
+
+#ifdef DEBUG
+static uint16_t frame_count = 0u;
+#endif
+
+static void enter(void) {
+    DISPLAY_OFF;
+    track_init();
+    camera_init(player_get_x(), player_get_y());
+    DISPLAY_ON;
+}
+
+static void update(uint8_t input) {
+#ifdef DEBUG
+    frame_count++;
+    if (frame_count % 60u == 0u) {
+        DBG_INT("frame", (int)frame_count);
+        DBG_INT("px", (int)player_get_x());
+        DBG_INT("py", (int)player_get_y());
+    }
+#endif
+    /* VBlank phase: all VRAM writes immediately after wait_vbl_done() */
+    player_render();
+    camera_flush_vram();
+    /* SCY is 8-bit and wraps at 256. Truncation is correct: stream_row() places
+     * world row ty at VRAM row (ty & 31), so (uint8_t)cam_y correctly indexes
+     * the ring buffer. */
+    move_bkg(0u, (uint8_t)cam_y);
+    /* Game logic phase: runs during active display */
+    player_update(input);
+    camera_update(player_get_x(), player_get_y());
+}
+
+static void sp_exit(void) {
+}
+
+const State state_playing = { enter, update, sp_exit };

--- a/src/state_playing.h
+++ b/src/state_playing.h
@@ -1,0 +1,8 @@
+#ifndef STATE_PLAYING_H
+#define STATE_PLAYING_H
+
+#include "state_manager.h"
+
+extern const State state_playing;
+
+#endif

--- a/src/state_title.c
+++ b/src/state_title.c
@@ -1,0 +1,25 @@
+#include <gb/gb.h>
+#include <gbdk/console.h>
+#include <stdio.h>
+#include "state_manager.h"
+#include "state_title.h"
+#include "state_playing.h"
+
+static void enter(void) {
+    cls();
+    gotoxy(2, 6);
+    printf("WASTELAND RACER");
+    gotoxy(3, 10);
+    printf("Press START");
+}
+
+static void update(uint8_t input) {
+    if (input & J_START) {
+        state_replace(&state_playing);
+    }
+}
+
+static void st_exit(void) {
+}
+
+const State state_title = { enter, update, st_exit };

--- a/src/state_title.h
+++ b/src/state_title.h
@@ -1,0 +1,8 @@
+#ifndef STATE_TITLE_H
+#define STATE_TITLE_H
+
+#include "state_manager.h"
+
+extern const State state_title;
+
+#endif

--- a/tests/test_state_manager.c
+++ b/tests/test_state_manager.c
@@ -1,0 +1,152 @@
+#include "unity.h"
+#include "../src/state_manager.h"
+#include <stdint.h>
+
+/* ── Call tracking ────────────────────────────────────────────────── */
+static int calls_a_enter = 0;
+static int calls_a_update = 0;
+static int calls_a_exit = 0;
+static int calls_b_enter = 0;
+static int calls_b_update = 0;
+static int calls_b_exit = 0;
+
+/* Track call order globally */
+static int call_order[16];
+static int call_order_len = 0;
+
+#define LOG_A_ENTER  1
+#define LOG_A_EXIT   2
+#define LOG_B_ENTER  3
+#define LOG_B_EXIT   4
+
+static void a_enter(void)  { calls_a_enter++;  call_order[call_order_len++] = LOG_A_ENTER; }
+static void a_update(uint8_t input) { (void)input; calls_a_update++; }
+static void a_exit(void)   { calls_a_exit++;   call_order[call_order_len++] = LOG_A_EXIT; }
+
+static void b_enter(void)  { calls_b_enter++;  call_order[call_order_len++] = LOG_B_ENTER; }
+static void b_update(uint8_t input) { (void)input; calls_b_update++; }
+static void b_exit(void)   { calls_b_exit++;   call_order[call_order_len++] = LOG_B_EXIT; }
+
+static const State state_a = { a_enter, a_update, a_exit };
+static const State state_b = { b_enter, b_update, b_exit };
+
+/* ── setUp / tearDown ─────────────────────────────────────────────── */
+void setUp(void) {
+    calls_a_enter = calls_a_update = calls_a_exit = 0;
+    calls_b_enter = calls_b_update = calls_b_exit = 0;
+    call_order_len = 0;
+    state_manager_init();
+}
+
+void tearDown(void) {}
+
+/* ── Tests ────────────────────────────────────────────────────────── */
+
+/* push calls enter on the pushed state */
+void test_push_calls_enter(void) {
+    state_push(&state_a);
+    TEST_ASSERT_EQUAL_INT(1, calls_a_enter);
+}
+
+/* update calls the top state's update */
+void test_update_calls_top_state_update(void) {
+    state_push(&state_a);
+    state_manager_update(0);
+    TEST_ASSERT_EQUAL_INT(1, calls_a_update);
+    TEST_ASSERT_EQUAL_INT(0, calls_b_update);
+}
+
+/* push a second state — update goes to the new top, not the base */
+void test_push_second_update_routes_to_top(void) {
+    state_push(&state_a);
+    state_push(&state_b);
+    state_manager_update(0);
+    TEST_ASSERT_EQUAL_INT(0, calls_a_update);
+    TEST_ASSERT_EQUAL_INT(1, calls_b_update);
+}
+
+/* pop: calls exit on top, then enter on resumed base state */
+void test_pop_calls_exit_then_base_enter(void) {
+    state_push(&state_a);
+    state_push(&state_b);
+    /* reset counters after setup so we only measure the pop */
+    calls_a_enter = 0;
+    calls_b_exit  = 0;
+    call_order_len = 0;
+
+    state_pop();
+
+    TEST_ASSERT_EQUAL_INT(1, calls_b_exit);
+    TEST_ASSERT_EQUAL_INT(1, calls_a_enter);
+    /* exit must precede enter */
+    TEST_ASSERT_EQUAL_INT(LOG_B_EXIT,  call_order[0]);
+    TEST_ASSERT_EQUAL_INT(LOG_A_ENTER, call_order[1]);
+}
+
+/* pop: after popping modal, update routes back to base state */
+void test_pop_routes_update_to_base(void) {
+    state_push(&state_a);
+    state_push(&state_b);
+    state_pop();
+    calls_a_update = 0;
+    calls_b_update = 0;
+
+    state_manager_update(0);
+    TEST_ASSERT_EQUAL_INT(1, calls_a_update);
+    TEST_ASSERT_EQUAL_INT(0, calls_b_update);
+}
+
+/* replace: calls exit on old top, enter on new top; depth unchanged */
+void test_replace_calls_exit_then_enter(void) {
+    state_push(&state_a);
+    calls_a_enter = 0;
+    call_order_len = 0;
+
+    state_replace(&state_b);
+
+    TEST_ASSERT_EQUAL_INT(1, calls_a_exit);
+    TEST_ASSERT_EQUAL_INT(1, calls_b_enter);
+    /* order: exit before enter */
+    TEST_ASSERT_EQUAL_INT(LOG_A_EXIT,  call_order[0]);
+    TEST_ASSERT_EQUAL_INT(LOG_B_ENTER, call_order[1]);
+}
+
+/* replace: update routes to the new state, not the old one */
+void test_replace_routes_update_to_new_state(void) {
+    state_push(&state_a);
+    state_replace(&state_b);
+    calls_a_update = 0;
+    calls_b_update = 0;
+
+    state_manager_update(0);
+    TEST_ASSERT_EQUAL_INT(0, calls_a_update);
+    TEST_ASSERT_EQUAL_INT(1, calls_b_update);
+}
+
+/* overflow guard: pushing beyond capacity does not crash and does not
+ * corrupt the stack. The third push is silently ignored. */
+void test_push_beyond_capacity_is_safe(void) {
+    static const State state_c = { a_enter, a_update, a_exit }; /* reuse fns */
+    state_push(&state_a);
+    state_push(&state_b);
+    state_push(&state_c); /* depth already at max — must not crash */
+
+    /* update must still work (routes to state_b, the last valid top) */
+    calls_b_update = 0;
+    state_manager_update(0);
+    TEST_ASSERT_EQUAL_INT(1, calls_b_update);
+}
+
+/* ── main ─────────────────────────────────────────────────────────── */
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_push_calls_enter);
+    RUN_TEST(test_update_calls_top_state_update);
+    RUN_TEST(test_push_second_update_routes_to_top);
+    RUN_TEST(test_pop_calls_exit_then_base_enter);
+    RUN_TEST(test_pop_routes_update_to_base);
+    RUN_TEST(test_replace_calls_exit_then_enter);
+    RUN_TEST(test_replace_routes_update_to_new_state);
+    RUN_TEST(test_push_beyond_capacity_is_safe);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Extracts a formal `state_manager` module: 2-slot function-pointer stack with `state_push`, `state_pop`, `state_replace` semantics
- Moves title and playing logic into `state_title.c` / `state_playing.c`; `main.c` now only drives `wait_vbl_done()` + `state_manager_update(joypad())`
- Adds 8 unit tests covering push/update routing, pop order (exit→enter), replace, and overflow guard

## Test Plan
- [x] `make test` — 69 tests, 0 failures (8 new state_manager tests)
- [x] `GBDK_HOME=~/gbdk make` — ROM builds cleanly at 32K
- [x] Emulator smoketest — title screen shows, START transitions to gameplay, player moves