### PR TITLE
chore: remove dead lcd_isr, fix PLAYER_HP typo, update stale comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ This project uses [Superpowers](https://github.com/obra/superpowers) (installed 
 **TDD red/green command:** `make test` (gcc + Unity, no hardware needed — use `/test` skill)
 **Build verification:** `GBDK_HOME=/home/mathdaman/gbdk make` (use `/build` skill)
 **PRDs & design docs:** GitHub issues only — no local files. Use `/prd` skill.
+**Brainstorming skill override:** Skip step 5 (write design doc to `docs/plans/`) — use `/prd` to create a GitHub issue instead.
 
 **Worktree policy:** ALL file writes — including implementation plans, code, tests, and docs — MUST happen inside a git worktree. Use the `using-git-worktrees` skill or `EnterWorktree` tool before writing any files. Never write implementation files directly to the main working tree.
 

--- a/src/config.h
+++ b/src/config.h
@@ -16,13 +16,13 @@
 /* Player vehicle stats — reserved for future systems; values are tunable placeholders */
 #define PLAYER_HANDLING  3   /* Turning/handling system (not yet implemented) */
 #define PLAYER_ARMOR     5   /* Damage system: reduces incoming damage before it applies to HP */
-#define PLAYER_HP        10  /* Damage system: raw health pool (hp -= damage - armor) */
+#define PLAYER_HP        100 /* Damage system: starting HP (equals PLAYER_HP_MAX — full health) */
 #define PLAYER_FUEL      20  /* Fuel depletion system (not yet implemented) */
 
 #define MAP_TILES_W  20u
 #define MAP_TILES_H  100u
 
-#define HUD_SCANLINE 128  /* LYC fires here: 2-tile HUD = 16px at bottom, scanline 128 is first HUD line */
+#define HUD_SCANLINE 128  /* pixel row where HUD window begins; used for player movement bounds */
 #define PLAYER_HP_MAX 100
 
 /* Terrain physics modifiers */

--- a/src/main.c
+++ b/src/main.c
@@ -37,10 +37,6 @@ static void vbl_isr(void) {
     move_bkg(0, (uint8_t)cam_y);
 }
 
-static void lcd_isr(void) {
-    move_bkg(0, 0);
-}
-
 void main(void) {
     DISPLAY_OFF;
 
@@ -48,7 +44,6 @@ void main(void) {
     player_init();
     add_VBL(vbl_isr);
     set_interrupts(VBL_IFLAG);
-    /* LCD ISR (lcd_isr / LYC_REG / STATF_LYC) enabled when HUD is implemented */
 
     DISPLAY_ON;
 


### PR DESCRIPTION
## Summary

- **Remove `lcd_isr`** — HUD uses the window layer (hardware-pinned at WY=128), making the split-scroll background ISR unnecessary; function was dead code
- **Fix `PLAYER_HP` 10 → 100** — should equal `PLAYER_HP_MAX`; was a typo
- **Update `HUD_SCANLINE` comment** — removed stale reference to LYC/split-scroll; constant is still used in `player.c` for movement bounds
- **CLAUDE.md** — add explicit override for brainstorming skill step 5 (no local design docs; use `/prd` instead)

## Test plan

- [x] `GBDK_HOME=/home/mathdaman/gbdk make` — clean build, 32K ROM, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)