### PR TITLE
feat: add sprite-expert skill

### DIFF
--- a/.claude/skills/map-expert/SKILL.md
+++ b/.claude/skills/map-expert/SKILL.md
@@ -268,3 +268,9 @@ The project uses **TMX (XML)** with **CSV encoding**:
 | `encoding: "csv"` in XML = string | Split on `','`, not a JSON array |
 | Tile index formula wrong | Use `layer.width`, not map `width` |
 | Object `type` vs `class` | Pre-1.9: `type` field; since 1.9: `class` field |
+
+---
+
+## Cross-References
+
+- **`sprite-expert`** — OAM sprite asset pipeline, sprite pool, sprite tile loading; use for anything that involves sprites rather than background/window tiles

--- a/.claude/skills/sprite-expert/SKILL.md
+++ b/.claude/skills/sprite-expert/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: sprite-expert
+description: Use when creating sprites, editing sprite assets, changing how sprites are loaded or rendered, adding new sprite types, modifying the sprite pool, changing OAM slot assignments, updating sprite tile data, or working with the sprite editor or png_to_tiles pipeline.
+---
+
+# Sprite Expert — Wasteland Racer
+
+**Update this skill whenever the sprite system changes** (new pipeline steps, new API usage, pool budget changes, coordinate system corrections).
+
+---
+
+## Asset Pipeline
+
+```
+tools/sprite_editor/  →  assets/sprites/<name>.png  →  tools/png_to_tiles.py  →  src/<name>_sprite.c
+```
+
+| Step | Tool | Notes |
+|------|------|-------|
+| Draw pixels | `python3 tools/run_sprite_editor.py` (GTK3) | 4×4 grid of 8×8 tiles (32×32 px); saves 2-bit indexed PNG |
+| Convert | `python3 tools/png_to_tiles.py <in.png> src/<name>_sprite.c <array_name>` | Emits `const uint8_t <array_name>[]` + `<array_name>_count` |
+| Use | `extern` declare in `.c` file that calls `set_sprite_data` | Generated file — **never edit by hand** |
+
+**PNG requirements for `png_to_tiles.py`:**
+- Color type 3 (indexed), bit depth 2 — produced automatically by the sprite editor
+- OR color type 2 (RGB8) with ≤ 4 distinct luminance values
+- Dimensions must be multiples of 8
+- Each 8×8 block = one tile; tiles read left-to-right, top-to-bottom
+
+**Run tests after any converter change:**
+```sh
+python3 -m unittest discover -s tests -p "test_png_to_tiles.py" -v
+python3 -m unittest discover -s tests -p "test_sprite_editor.py" -v
+```
+
+---
+
+## Sprite Pool (`src/sprite_pool.h`)
+
+Manages OAM slot allocation. **Always use the pool** — never hardcode OAM indices.
+
+```c
+sprite_pool_init();              /* call once in player_init(); resets all 40 slots */
+uint8_t slot = get_sprite();     /* returns next free slot, or SPRITE_POOL_INVALID */
+clear_sprite(slot);              /* move_sprite(slot,0,0) + mark free */
+clear_sprites_from(slot);        /* clear slot..MAX_SPRITES-1 */
+```
+
+`SPRITE_POOL_INVALID = 0xFF` — always check return value before using slot.
+
+**OAM budget (MAX_SPRITES = 40):**
+- Player: 2 slots (top half + bottom half in 8×8 mode)
+- Remaining 38 for enemies, projectiles, HUD sprites
+
+---
+
+## GBDK Sprite API
+
+```c
+/* Load tile data into VRAM (do this during VBlank or with display off) */
+set_sprite_data(first_tile_idx, n_tiles, data_ptr);  /* NOT set_sprite_tile_data */
+
+/* Assign a VRAM tile to an OAM slot */
+set_sprite_tile(oam_slot, tile_idx);
+
+/* Position a sprite (OAM coordinate system — see below) */
+move_sprite(oam_slot, oam_x, oam_y);
+
+/* Mode and visibility */
+SPRITES_8x8;    /* LCDC bit 2 = 0; call before loading sprite data */
+SPRITES_8x16;   /* LCDC bit 2 = 1; tile bit 0 is ignored; top=tile&0xFE, bot=tile|0x01 */
+SHOW_SPRITES;   /* LCDC bit 1 = 1 */
+HIDE_SPRITES;   /* LCDC bit 1 = 0 */
+```
+
+**Wrong name:** `set_sprite_tile_data` does NOT exist. Use `set_sprite_data`.
+
+---
+
+## Coordinate System
+
+OAM stores raw hardware coordinates. `move_sprite(slot, oam_x, oam_y)`:
+
+```
+screen_x = oam_x - 8    (DEVICE_SPRITE_PX_OFFSET_X = 8)
+screen_y = oam_y - 16   (DEVICE_SPRITE_PX_OFFSET_Y = 16)
+```
+
+**To place a sprite at screen pixel (sx, sy):**
+```c
+move_sprite(slot, (uint8_t)(sx + 8), (uint8_t)(sy + 16));
+```
+
+**Fully visible range (8×8 sprite):**
+- `oam_x` ∈ [8, 167] → screen x ∈ [0, 159]
+- `oam_y` ∈ [16, 159] → screen y ∈ [0, 143]
+
+**Hide a sprite:** `move_sprite(slot, 0, 0)` — OAM y=0 is always off-screen.
+
+**Common mistake:** using 152 or 136 as max oam_x/oam_y — these cut off ~15px of valid screen area.
+
+**Player render pattern (camera-adjusted):**
+```c
+uint8_t hw_x = (uint8_t)(px + 8);
+uint8_t hw_y = (uint8_t)((int16_t)py - (int16_t)cam_y + 16);
+move_sprite(player_sprite_slot,     hw_x, hw_y);
+move_sprite(player_sprite_slot_bot, hw_x, (uint8_t)(hw_y + 8u));
+```
+
+---
+
+## CGB Palettes for Sprites
+
+- Use `set_sprite_palette(pal_nb, n_palettes, pal_data)` or `OCPD` registers
+- 8 OBJ palettes (0–7), 4 colors each, 5-bit RGB: `RGB(r, g, b)` (values 0–31)
+- **Color index 0 is always transparent** — usable sprite colors: indices 1, 2, 3
+- OAM attribute byte bits 2–0 select CGB palette (0–7)
+- Cannot write OCPD during PPU Mode 3 — update during VBlank only
+
+---
+
+## VBlank Timing
+
+`set_sprite_data` writes to VRAM — **must be called during VBlank or with display off**.
+
+```c
+wait_vbl_done();                          /* wait for VBlank */
+set_sprite_data(0, n, tile_data_array);   /* VRAM write — safe in VBlank */
+```
+
+`move_sprite` writes to OAM shadow buffer (GBDK copies it via DMA) — safe anytime.
+
+---
+
+## Adding a New Sprite
+
+1. Draw in `tools/sprite_editor/` → save as `assets/sprites/<name>.png`
+2. Run: `python3 tools/png_to_tiles.py assets/sprites/<name>.png src/<name>_sprite.c <name>_tile_data`
+3. In your `.c` file: `extern const uint8_t <name>_tile_data[]; extern const uint8_t <name>_tile_data_count;`
+4. In init: `wait_vbl_done(); set_sprite_data(base_tile, <name>_tile_data_count, <name>_tile_data);`
+5. Allocate OAM slots via `get_sprite()` — one per 8×8 tile used on screen at once
+6. Position with `move_sprite(slot, sx + 8, sy + 16)`
+7. Update `config.h` capacity constants if pool budget changes
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| `set_sprite_tile_data(...)` | Use `set_sprite_data(first, count, ptr)` |
+| Hardcoding OAM slot numbers | Use `get_sprite()` / `clear_sprite()` |
+| Calling `set_sprite_data` outside VBlank | Wrap with `wait_vbl_done()` unless display is off |
+| Using 152/136 as max position | Visible bounds: oam_x ∈ [8,167], oam_y ∈ [16,159] |
+| Editing `src/*_sprite.c` by hand | Generated — edit the PNG, re-run `png_to_tiles.py` |
+| Using palette index 0 for sprite pixels | Always transparent; use indices 1–3 |
+| Forgetting to check `SPRITE_POOL_INVALID` | `get_sprite()` returns `0xFF` when pool is full |
+| Loading tile data before `SPRITES_8x8` | Set mode first, then load data and assign tiles |
+
+---
+
+## Cross-References
+
+- **`gbdk-expert`** — OAM hardware registers, PPU modes, CGB palette registers, VBlank timing details
+- **`map-expert`** — Tiled map/tileset format; tile data pipeline for background tiles (not sprites)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ Always use `gh` for git push/pull and GitHub operations. Run `gh auth setup-git`
 
 - **`gbdk-expert`** — GBDK-2020 API, hardware registers, sprites/palettes/interrupts, MBC banking, compilation errors.
 - **`gb-c-optimizer`** — C code review for GBC performance/ROM size, anti-pattern detection, SDCC optimization.
-- **`/map-expert`** — Map pipeline: Tiled TMX format, Python converters (`tmx_to_c`, `png_to_tiles`, `gen_tileset`), GB BG tilemap hardware. Use when creating or modifying maps. **Update this skill in the same PR** whenever the pipeline changes.
+- **`/map-expert`** — Map pipeline: Tiled TMX format, Python converters (`tmx_to_c`, `gen_tileset`), GB BG tilemap hardware. Use when creating or modifying maps. **Update this skill in the same PR** whenever the pipeline changes.
+- **`/sprite-expert`** — Sprite pipeline: sprite editor, `png_to_tiles.py`, sprite pool, OAM API, CGB palette for sprites, coordinate system. Use when creating or modifying sprites. **Update this skill in the same PR** whenever the sprite system changes.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/sprite-expert/SKILL.md` — full reference skill covering the complete sprite workflow
- Updates `map-expert` with a cross-reference to `sprite-expert`
- Updates `CLAUDE.md` to register `/sprite-expert` in the Specialized Agents section with an update-on-change policy

## What the skill covers
- **Asset pipeline**: sprite editor → `assets/sprites/*.png` → `png_to_tiles.py` → generated `src/*_sprite.c`
- **Sprite pool API**: `get_sprite()`, `clear_sprite()`, `sprite_pool_init()`, `SPRITE_POOL_INVALID`
- **GBDK OAM API**: `set_sprite_data` (correct name), `set_sprite_tile`, `move_sprite`, `SPRITES_8x8/8x16`
- **Coordinate system**: OAM offset (+8/+16), visible bounds [8,167] × [16,159], hide-by-zero
- **CGB palettes**: index 0 transparent, 5-bit RGB, VBlank timing requirement
- **Common mistakes**: wrong API name, hardcoded OAM slots, wrong bounds, editing generated files
- **Update policy**: skill must be updated in the same PR as any sprite system change

## Test plan
- [ ] Verify skill is discoverable: check description triggers on "create sprite", "change sprite", "sprite pool"
- [ ] Spot-check coordinate system against `src/player.c:72–75` — matches `px + 8` / `py - cam_y + 16` pattern
- [ ] Verify API names against `gbdk-expert` skill — `set_sprite_data` confirmed correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)