### PR TITLE
feat: add map-builder and sprite-builder skills

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -75,7 +75,7 @@
       "Bash(mv ~/.local/squashfs-root ~/.local/aseprite && ln -sf ~/.local/aseprite/AppRun ~/.local/bin/aseprite && echo \"Done\")",
       "Bash(ls /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/sprite-expert-skill/tests/*.py)",
       "Bash(GBDK_HOME=/home/mathdaman/gbdk make 2>&1 | grep -v \"^$\" | grep -v \"warning\" | tail -10)",
-      "Bash(aseprite --help 2>&1 | grep -A2 -i \"save\\\\|export\\\\|batch\")",
+      "Bash(aseprite --help 2>&1 | grep -A2 -i \"save\\|export\\|batch\")",
       "Bash(aseprite --batch assets/sprites/player_car.aseprite --save-as assets/sprites/player_car.png && aseprite --batch assets/maps/tileset.aseprite --save-as assets/maps/tileset.png && echo \"export OK\")",
       "Bash(curl -s https://raw.githubusercontent.com/SuperDisk/hUGEDriver/master/include/hUGEDriver.h)",
       "Bash(curl -s https://raw.githubusercontent.com/SuperDisk/hUGEDriver/master/README.md)",
@@ -88,13 +88,8 @@
       "Bash(curl -s https://raw.githubusercontent.com/SuperDisk/hUGEDriver/master/gbdk_example/src/gbdk_player_example.c)",
       "Bash(curl -s https://raw.githubusercontent.com/SuperDisk/hUGEDriver/master/gbdk_example/src/sample_song.c | wc -l)",
       "Bash(curl -s https://raw.githubusercontent.com/SuperDisk/hUGEDriver/master/gbdk_example/src/sample_song.c)",
-      "Bash(mkdir -p /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/hugedriver-music/lib/hUGEDriver/include /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/hugedriver-music/lib/hUGEDriver/gbdk && unzip -j /tmp/hUGEDriver.zip include/hUGEDriver.h -d /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/hugedriver-music/lib/hUGEDriver/include/ && unzip -j /tmp/hUGEDriver.zip gbdk/hUGEDriver.lib -d /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/hugedriver-music/lib/hUGEDriver/gbdk/ && echo \"Extraction complete\")",
-      "Bash(cd /tmp && wget -q https://github.com/SuperDisk/hUGETracker/releases/download/v1.0.11/hUGETracker-1.0.11-linux.zip -O hUGETracker.zip && unzip -o hUGETracker.zip -d hUGETracker/ && ls hUGETracker/)",
-      "Bash(git show:*)",
-      "Bash(file /home/mathdaman/gbdk/lib/sm83/*.lib 2>/dev/null | head -5; ls /home/mathdaman/gbdk/lib/sm83/*.lib 2>/dev/null | head -5)",
-      "Bash(cd /tmp && ar x /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/hugedriver-music/lib/hUGEDriver/gbdk/hUGEDriver.lib && ls -la && head -5 hUGEDriver.o)",
-      "Bash(GBDK_HOME=/home/mathdaman/gbdk /home/mathdaman/gbdk/bin/sdldgb -n -i -m -j -g _shadow_OAM=0xC000 -g .STACK=0xE000 -g .refresh_OAM=0xFF80 -b _DATA=0xC0A0 -b _CODE=0x0200 -k \"/home/mathdaman/gbdk/lib/sm83/\" -l sm83.lib -k \"/home/mathdaman/gbdk/lib/gb/\" -l gb.lib /tmp/test_music2.ihx \"/home/mathdaman/gbdk/lib/gb/crt0.o\" -f /tmp/test_banks2.lk 2>&1 | head -20)",
-      "Bash(# First put the correct .rel back\ncp /tmp/hUGEDriver.o /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/hugedriver-music/lib/hUGEDriver/gbdk/hUGEDriver.rel\n\n# Now run bankpack with verbose to see what it does\nGBDK_HOME=/home/mathdaman/gbdk /home/mathdaman/gbdk/bin/bankpack --help 2>&1 | head -20)"
+      "Bash(git -C /home/mathdaman/code/gmb-wasteland-racer branch --show-current && ls /home/mathdaman/code/gmb-wasteland-racer/src/overmap*.c 2>/dev/null || echo \"no overmap files in main tree\")",
+      "Bash(pwd && ls src/overmap*.c 2>/dev/null || echo \"no overmap in cwd\" && ls /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/sprite-expert-skill/src/overmap*.c)"
     ]
   }
 }

--- a/.claude/skills/map-builder/SKILL.md
+++ b/.claude/skills/map-builder/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: map-builder
+description: Use when creating a new map or track for Wasteland Racer — designing the layout, drawing in Tiled, running the TMX conversion pipeline, and wiring the generated C files into the game.
+---
+
+# Map Builder
+
+## Overview
+
+Step-by-step guide to create a new map from scratch. Uses the Tiled → `tmx_to_c.py` → GB pipeline.
+
+**REQUIRED BACKGROUND:** Invoke the `map-expert` skill before writing any code — it has the full pipeline reference, GID rules, and GBDK API details.
+
+---
+
+## Quick Checklist
+
+1. [ ] Design tile vocabulary (what terrain types does the map need?)
+2. [ ] Draw or update tileset in Aseprite → export PNG → run `png_to_tiles.py`
+3. [ ] Open/create map in Tiled — set dimensions, tile size 8×8
+4. [ ] Paint layout — place `start` objectgroup with one spawn object
+5. [ ] Save TMX → run `tmx_to_c.py` → verify generated C
+6. [ ] Wire C files into the game (update `#include`, call init/load)
+7. [ ] Build and smoketest in Emulicious
+
+---
+
+## Step 1 — Tileset
+
+If extending the existing tileset (`assets/maps/tileset.aseprite`):
+- Add new 8×8 tiles in Aseprite (indexed color, 4-shade GBC palette)
+- Export: `make export-sprites` or `aseprite --batch assets/maps/tileset.aseprite --save-as assets/maps/tileset.png`
+- Regenerate tile C array: `python3 tools/png_to_tiles.py assets/maps/tileset.png src/track_tiles.c track_tile_data`
+
+If creating a new tileset for a new map:
+- New `.aseprite` under `assets/maps/<mapname>_tiles.aseprite`
+- Export to `assets/maps/<mapname>_tiles.png`
+- Convert: `python3 tools/png_to_tiles.py assets/maps/<mapname>_tiles.png src/<mapname>_tiles.c <mapname>_tile_data`
+
+**Tile budget:** 192 tiles in DMG bank 0, 192 more in CGB bank 1. Keep total unique tiles ≤ 192 for DMG compat.
+
+---
+
+## Step 2 — Draw the Map in Tiled
+
+1. Open Tiled → New Map → **Tile size: 8×8px**, map dimensions in tiles (current: 40×36)
+2. Add your tileset: Map → Add External Tileset → point to `.tsx` (or create one from the PNG)
+3. Paint the tile layer named **"Track"** (layer name matters for `tmx_to_c.py`)
+4. Add spawn point: Layer → New Object Layer named **"start"** → Insert Point → place it on the road
+5. Save as `assets/maps/<name>.tmx` with **CSV encoding** (File → Map Properties → Tile Layer Format: CSV)
+
+**Map constraints:**
+- Tile size must be **8×8** (one GB tile)
+- Layer encoding must be **CSV** (not base64/zlib)
+- Must have one objectgroup named `start` with exactly one object
+
+---
+
+## Step 3 — Convert TMX → C
+
+```sh
+python3 tools/tmx_to_c.py assets/maps/<name>.tmx src/<name>_map.c
+```
+
+Outputs `src/<name>_map.c` with:
+- `track_start_x`, `track_start_y` — spawn pixel coords
+- `track_map[]` — tile index array, row-major
+
+Run the conversion tests to verify the tool still works:
+```sh
+python3 -m unittest discover -s tests -p "test_tmx_to_c.py" -v
+```
+
+**Never edit `src/<name>_map.c` by hand** — it is generated. Edit the TMX and re-run.
+
+---
+
+## Step 4 — Wire Into the Game
+
+In the relevant `.h` / `.c` for your map system:
+
+```c
+/* Declare generated symbols (in your map .h) */
+extern const uint8_t track_map[];
+extern const int16_t track_start_x;
+extern const int16_t track_start_y;
+extern const uint8_t track_tile_data[];
+extern const uint8_t track_tile_data_count;
+```
+
+Loading sequence (must happen during / immediately after VBlank):
+
+```c
+wait_vbl_done();
+set_bkg_data(0, track_tile_data_count, track_tile_data);  /* load tile graphics */
+set_bkg_tiles(0, 0, MAP_TILES_W, MAP_TILES_H, track_map); /* write tilemap */
+SHOW_BKG;
+```
+
+**Map dimensions** must be declared in `src/config.h`:
+```c
+#define MAP_TILES_W  40
+#define MAP_TILES_H  36
+```
+
+Update these if your new map has different dimensions.
+
+---
+
+## Step 5 — Banking (if map data is large)
+
+Generated files from `tmx_to_c.py` already include `#pragma bank 255` and `BANKREF`. When loading:
+
+```c
+{ SET_BANK(track_map);
+  set_bkg_tiles(0, 0, MAP_TILES_W, MAP_TILES_H, track_map);
+  RESTORE_BANK(); }
+```
+
+Wrap tile data load similarly if `track_tile_data` is in a banked file.
+
+---
+
+## Step 6 — Build & Smoketest
+
+```sh
+GBDK_HOME=/home/mathdaman/gbdk make
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
+```
+
+Check:
+- Map renders correctly (no garbage tiles)
+- Player spawns at the right position
+- Scrolling wraps without glitches
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Editing generated `src/*_map.c` by hand | Always edit the TMX and re-run `tmx_to_c.py` |
+| Map layer not named "Track" | `tmx_to_c.py` looks for this layer name exactly |
+| Missing `start` objectgroup | Script requires exactly one objectgroup named `start` |
+| VRAM writes after game logic | Always call `wait_vbl_done()` → tile data → tilemap → then game logic |
+| Tile count > 192 | DMG VRAM limit; use CGB bank 1 for overflow or reduce tiles |
+| Using base64 encoding in Tiled | Set Tile Layer Format to **CSV** before saving |
+
+---
+
+## Cross-References
+
+- **`map-expert`** — Full pipeline reference, GID math, GBDK BG API, CGB attribute map
+- **`sprite-expert`** — For OAM sprites on top of the map
+- **`gbdk-expert`** — VBlank rules, LCDC register, set_bkg_data details

--- a/.claude/skills/sprite-builder/SKILL.md
+++ b/.claude/skills/sprite-builder/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: sprite-builder
+description: Use when adding a new sprite type to Wasteland Racer — creating the Aseprite source, exporting PNG, running png_to_tiles, allocating OAM slots, loading tile data, and rendering the sprite in game.
+---
+
+# Sprite Builder
+
+## Overview
+
+Step-by-step guide to add a new sprite from scratch. Uses the Aseprite → `png_to_tiles.py` → OAM pool pipeline.
+
+**REQUIRED BACKGROUND:** Invoke the `sprite-expert` skill before writing any code — it has the full API reference, OAM coordinate math, palette setup, and VBlank rules.
+
+---
+
+## Quick Checklist
+
+1. [ ] Draw sprite in Aseprite (indexed color, 4-shade GBC palette, 8×N canvas)
+2. [ ] Export PNG → run `png_to_tiles.py` → verify generated C
+3. [ ] Declare `extern` symbols in the consumer `.c`
+4. [ ] Load tile data during VBlank (`set_sprite_data`)
+5. [ ] Allocate OAM slots via `get_sprite()` — one per 8×8 tile visible at once
+6. [ ] Assign tile indices (`set_sprite_tile`) and position (`move_sprite`)
+7. [ ] Update `src/config.h` if pool budget changes
+8. [ ] Build and smoketest in Emulicious
+
+---
+
+## Step 1 — Draw in Aseprite
+
+- Open Aseprite → New → width/height multiples of 8 (e.g., 8×16 for a 2-tile tall sprite)
+- Color mode: **Sprite → Color Mode → Indexed**
+- Set palette to exactly 4 entries: `#FFFFFF` (idx 0), `#AAAAAA` (idx 1), `#555555` (idx 2), `#000000` (idx 3)
+- **Index 0 is always transparent** — never use it for visible pixels
+- Save as `assets/sprites/<name>.aseprite`
+
+---
+
+## Step 2 — Export and Convert
+
+```sh
+# Export PNG (batch mode)
+aseprite --batch assets/sprites/<name>.aseprite --save-as assets/sprites/<name>.png
+
+# Or batch-export all sources at once
+make export-sprites
+
+# Convert PNG → GB 2bpp C array
+python3 tools/png_to_tiles.py assets/sprites/<name>.png src/<name>_sprite.c <name>_tile_data
+```
+
+This generates `src/<name>_sprite.c` with:
+```c
+const uint8_t <name>_tile_data[];       /* 16 bytes × N tiles */
+const uint8_t <name>_tile_data_count;   /* number of tiles */
+```
+
+**Never edit generated `src/<name>_sprite.c` by hand.**
+
+Run converter tests after any change:
+```sh
+python3 -m unittest discover -s tests -p "test_png_to_tiles.py" -v
+```
+
+---
+
+## Step 3 — Declare and Load
+
+In the `.c` file that manages this sprite:
+
+```c
+/* Declare generated symbols */
+extern const uint8_t <name>_tile_data[];
+extern const uint8_t <name>_tile_data_count;
+
+/* Reserve a tile base index in config.h, e.g.: */
+/* #define SPRITE_TILE_BASE_<NAME>  4 */
+```
+
+Load during init (must be during VBlank or with display off):
+
+```c
+wait_vbl_done();
+SPRITES_8x8;   /* set mode before loading data */
+set_sprite_data(SPRITE_TILE_BASE_<NAME>, <name>_tile_data_count, <name>_tile_data);
+```
+
+---
+
+## Step 4 — Allocate OAM Slots
+
+```c
+/* In your init function — always use the pool, never hardcode slot numbers */
+uint8_t slot = get_sprite();
+if (slot == SPRITE_POOL_INVALID) {
+    /* handle exhausted pool */
+    return;
+}
+set_sprite_tile(slot, SPRITE_TILE_BASE_<NAME>);
+```
+
+For a 2-tile sprite (e.g., 8×16 = top + bottom):
+```c
+uint8_t slot_top = get_sprite();
+uint8_t slot_bot = get_sprite();
+set_sprite_tile(slot_top, SPRITE_TILE_BASE_<NAME>);
+set_sprite_tile(slot_bot, SPRITE_TILE_BASE_<NAME> + 1);
+```
+
+---
+
+## Step 5 — Position the Sprite
+
+OAM coordinates include a hardware offset — always add it:
+
+```c
+/* Place sprite at screen pixel (sx, sy) */
+move_sprite(slot, (uint8_t)(sx + 8), (uint8_t)(sy + 16));
+
+/* For a 2-tile sprite: */
+move_sprite(slot_top, (uint8_t)(sx + 8), (uint8_t)(sy + 16));
+move_sprite(slot_bot, (uint8_t)(sx + 8), (uint8_t)(sy + 24));  /* +8 for second tile */
+```
+
+Fully visible screen range: `oam_x ∈ [8, 167]`, `oam_y ∈ [16, 159]`.
+To hide: `move_sprite(slot, 0, 0)`.
+
+---
+
+## Step 6 — CGB Palette (optional)
+
+```c
+/* Define 4 colors (5-bit RGB, index 0 = transparent) */
+const uint16_t my_palette[] = {
+    RGB(31, 31, 31),  /* idx 0: white (transparent) */
+    RGB(20, 20, 20),  /* idx 1: light grey */
+    RGB(10, 10, 10),  /* idx 2: dark grey */
+    RGB(0,  0,  0),   /* idx 3: black */
+};
+set_sprite_palette(0, 1, my_palette);  /* palette 0, 1 palette entry */
+```
+
+Must be called during VBlank. OAM attribute bits 2–0 select which of the 8 OBJ palettes to use.
+
+---
+
+## Step 7 — Update Config
+
+If adding sprite slots changes the OAM budget, update `src/config.h`:
+```c
+#define MAX_ENEMY_SPRITES  8  /* adjust pool-dependent limits here */
+```
+
+Document the OAM layout comment at the top of `config.h` so the budget stays auditable.
+
+---
+
+## Step 8 — Build & Smoketest
+
+```sh
+GBDK_HOME=/home/mathdaman/gbdk make
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
+```
+
+Check:
+- Sprite appears at correct position
+- No tile corruption (wrong tile base index?)
+- No flicker (pool exhausted? mode set after load?)
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| `set_sprite_tile_data(...)` | Use `set_sprite_data(first, count, ptr)` |
+| Hardcoding OAM slot number | Use `get_sprite()` / `clear_sprite()` |
+| Calling `set_sprite_data` outside VBlank | Wrap with `wait_vbl_done()` |
+| Palette index 0 for visible pixels | Always transparent — use indices 1–3 |
+| Using 152/136 as max OAM position | Valid bounds: oam_x ∈ [8,167], oam_y ∈ [16,159] |
+| Editing `src/*_sprite.c` by hand | Generated — edit `.aseprite` → re-export → re-run `png_to_tiles.py` |
+| Not calling `SPRITES_8x8` before loading | Set mode first, then load data |
+| Not checking `SPRITE_POOL_INVALID` | `get_sprite()` returns `0xFF` when pool is full |
+| Tile base collides with another sprite | Track tile base assignments in `config.h` |
+
+---
+
+## Cross-References
+
+- **`sprite-expert`** — Full API reference, coordinate system details, pool internals, CGB palette registers
+- **`gbdk-expert`** — OAM hardware, PPU modes, VBlank timing, LCDC register
+- **`map-expert`** — Background tile pipeline (BG tiles are separate from sprite tiles)


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/map-builder/SKILL.md` — step-by-step guide for creating a new map (Tiled authoring → `tmx_to_c.py` → C wiring → smoketest)
- Adds `.claude/skills/sprite-builder/SKILL.md` — step-by-step guide for adding a new sprite (Aseprite → `png_to_tiles.py` → OAM pool → VBlank load)
- Both skills complement the existing expert reference skills: they delegate deep API/hardware knowledge to `map-expert`/`sprite-expert` and focus on the creation workflow

## Relationship to existing skills

| Existing skill | Role | New skill | Role |
|---|---|---|---|
| `map-expert` | Reference — pipeline tools, GID math, GBDK BG API | `map-builder` | Creation guide — checklist, step-by-step wiring |
| `sprite-expert` | Reference — OAM API, coords, palette, VBlank | `sprite-builder` | Creation guide — checklist, step-by-step wiring |

## Test plan

- [ ] Invoke `/map-builder` skill and confirm description triggers correctly when creating a new map
- [ ] Invoke `/sprite-builder` skill and confirm description triggers correctly when adding a new sprite
- [ ] Verify cross-reference links point to correct existing skills (`map-expert`, `sprite-expert`, `gbdk-expert`)
- [ ] Confirm no build or test regressions: `make test` and `GBDK_HOME=/home/mathdaman/gbdk make`

🤖 Generated with [Claude Code](https://claude.com/claude-code)