### PR TITLE
feat: add /aseprite skill (CLI reference)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -89,7 +89,22 @@
       "Bash(curl -s https://raw.githubusercontent.com/SuperDisk/hUGEDriver/master/gbdk_example/src/sample_song.c | wc -l)",
       "Bash(curl -s https://raw.githubusercontent.com/SuperDisk/hUGEDriver/master/gbdk_example/src/sample_song.c)",
       "Bash(git -C /home/mathdaman/code/gmb-wasteland-racer branch --show-current && ls /home/mathdaman/code/gmb-wasteland-racer/src/overmap*.c 2>/dev/null || echo \"no overmap files in main tree\")",
-      "Bash(pwd && ls src/overmap*.c 2>/dev/null || echo \"no overmap in cwd\" && ls /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/sprite-expert-skill/src/overmap*.c)"
+      "Bash(pwd && ls src/overmap*.c 2>/dev/null || echo \"no overmap in cwd\" && ls /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/sprite-expert-skill/src/overmap*.c)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage build/wasteland-racer.gb -g 2>&1)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /tmp/wr-bisect-pre69/build/wasteland-racer.gb -g 2>&1)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage build/wasteland-racer.gb -a 2>&1 | head -60)",
+      "Bash(ls build/*.map build/*.noi build/*.sym 2>/dev/null | head -5)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/city-hub-mvp/build/wasteland-racer.gb -g 2>&1)",
+      "Bash(file /home/mathdaman/code/gmb-wasteland-racer/assets/maps/overmap_tiles.png && identify /home/mathdaman/code/gmb-wasteland-racer/assets/maps/overmap_tiles.png 2>/dev/null || echo \"identify not available\")",
+      "Bash(ls /home/mathdaman/code/gmb-wasteland-racer/.worktrees/feat-city-hub-mvp/src/state_city_hub* 2>/dev/null; grep -n \"CITY_HUB\\\\|city_hub\" /home/mathdaman/code/gmb-wasteland-racer/.worktrees/feat-city-hub-mvp/src/config.h 2>/dev/null || echo \"not in config.h\")",
+      "Bash(ls src/state_hub* src/hub_data* src/state_overmap* 2>/dev/null)",
+      "Bash(python3 -c \"\nfrom PIL import Image\nimg = Image.open\\('assets/maps/overmap_tiles.png'\\)\nprint\\(f'Size: {img.size}'\\)\n\" 2>/dev/null || identify assets/maps/overmap_tiles.png 2>/dev/null || file assets/maps/overmap_tiles.png)",
+      "Bash(aseprite --version 2>&1 | head -3)",
+      "Bash(aseprite --batch --script /tmp/add_hub_tile.lua --script-param file=assets/maps/overmap_tiles.aseprite assets/maps/overmap_tiles.aseprite 2>&1)",
+      "Bash(aseprite --batch assets/maps/overmap_tiles.aseprite --script /tmp/add_hub_tile.lua 2>&1)",
+      "Bash(aseprite --batch assets/maps/overmap_tiles.aseprite --save-as assets/maps/overmap_tiles.png 2>&1 | grep -v \"Unsupported chunk\")",
+      "Bash(aseprite --batch assets/maps/overmap_tiles.aseprite --script /tmp/sync_aseprite_tile.lua 2>&1 | grep -v \"Unsupported chunk\")",
+      "WebFetch(domain:www.aseprite.org)"
     ]
   }
 }

--- a/.claude/skills/aseprite/SKILL.md
+++ b/.claude/skills/aseprite/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: aseprite
+description: Use when running Aseprite from the command line, exporting sprites or sprite sheets, using --batch mode, working with Aseprite layers/tags/frames, scripting Aseprite, or looking up any aseprite CLI flag.
+---
+
+# Aseprite Reference
+
+## Invocation Pattern
+
+Always use `--batch` for non-interactive use. Without it, the GUI launches.
+
+```sh
+aseprite --batch <input.aseprite> [options]
+```
+
+**Order matters:** options apply to the most recently opened file. Put filters (--layer, --tag) *before* --save-as or --sheet.
+
+---
+
+## Core Flags
+
+| Flag | Effect |
+|------|--------|
+| `-b, --batch` | Run headless — no GUI. Required for scripts and CI. |
+| `-p, --preview` | Dry-run: print what would happen, write nothing. |
+| `-v, --verbose` | Log details to `aseprite.log`. |
+| `--debug` | Write `DebugOutput.txt` to desktop. |
+| `--version` | Print version and exit. |
+| `-?, --help` | List all CLI flags. |
+
+---
+
+## Export: Single File
+
+```sh
+# Export all frames as a PNG sequence (frame001.png, frame002.png, …)
+aseprite --batch sprite.aseprite --save-as output.png
+
+# Export as GIF
+aseprite --batch sprite.aseprite --save-as output.gif
+
+# Scale 2×
+aseprite --batch sprite.aseprite --scale 2 --save-as output.png
+```
+
+`--save-as <filename>` — exports the current sprite. When the sprite has multiple frames, Aseprite appends a zero-padded frame number automatically (e.g., `frame001.png`).
+
+**NOT a valid flag:** `--export-type` — use `--save-as` with the desired extension instead.
+
+---
+
+## Export: Sprite Sheet
+
+```sh
+aseprite --batch sprite.aseprite \
+  --sheet sheet.png \
+  --data sheet.json \
+  --format json-hash \
+  --sheet-type packed
+```
+
+| Flag | Values / Notes |
+|------|----------------|
+| `--sheet <file>` | Output PNG for the atlas |
+| `--data <file>` | Output JSON metadata |
+| `--format` | `json-hash` (default) or `json-array` |
+| `--sheet-type` | `horizontal` · `vertical` · `rows` · `columns` · `packed` |
+| `--sheet-width <px>` | Fix atlas width; height expands as needed |
+| `--sheet-height <px>` | Fix atlas height; width expands as needed |
+| `--sheet-pack` | Enable packing algorithm (same as `--sheet-type packed`) |
+| `--merge-duplicates` | Deduplicate identical frames in the atlas |
+| `--ignore-empty` | Skip empty frames/layers |
+| `--export-tileset` | Export tilesets from visible tilemap layers |
+
+---
+
+## Layer & Frame Filtering
+
+Apply these **before** `--save-as` or `--sheet`:
+
+```sh
+# Export only "Outline" layer
+aseprite --batch sprite.aseprite --layer "Outline" --save-as out.png
+
+# Export frames tagged "Run"
+aseprite --batch sprite.aseprite --tag "Run" --save-as run.png
+
+# Export frames 2–5 (0-based)
+aseprite --batch sprite.aseprite --frame-range 2,5 --save-as out.png
+
+# Split each tag into its own file  (use {tag} in filename)
+aseprite --batch sprite.aseprite --split-tags --save-as frames_{tag}.png
+```
+
+| Flag | Effect |
+|------|--------|
+| `--layer <name>` | Export one layer only |
+| `--all-layers` | Include hidden layers |
+| `--ignore-layer <name>` | Exclude a layer |
+| `--tag <name>` | Export frames within this animation tag |
+| `--frame-range from,to` | Export frame range (0-based inclusive) |
+| `--split-layers` | Each visible layer → separate file (must precede input filename) |
+| `--split-tags` | Each animation tag → separate file |
+| `--split-slices` | Each slice → separate file |
+| `--split-grid` | Each grid cell → separate file in sheet |
+
+---
+
+## Filename Format Variables
+
+Used with `--filename-format` and `--tagname-format`:
+
+| Variable | Expands to |
+|----------|-----------|
+| `{title}` | Sprite filename without extension |
+| `{tag}` | Current animation tag name |
+| `{layer}` | Layer name |
+| `{frame}` | Frame number (zero-padded) |
+| `{frames}` | Total frame count |
+| `{framenum}` | Frame number (no padding) |
+
+```sh
+aseprite --batch sprite.aseprite --split-tags \
+  --filename-format "{title}_{tag}_{frame}.png" \
+  --save-as out.png
+```
+
+---
+
+## Image Manipulation
+
+| Flag | Effect |
+|------|--------|
+| `--scale <factor>` | Resize (e.g., `--scale 2`) |
+| `--color-mode <mode>` | Convert: `rgb` · `grayscale` · `indexed` |
+| `--dithering-algorithm` | `none` · `ordered` · `old` |
+| `--dithering-matrix` | `bayer8x8` · `bayer4x4` · `bayer2x2` |
+| `--palette <file>` | Apply palette before export |
+| `--trim` | Remove empty border pixels |
+| `--trim-sprite` | Trim entire sprite bounds |
+| `--trim-by-grid` | Trim to grid boundaries |
+| `--crop x,y,w,h` | Export only this rect |
+| `--extrude` | Duplicate edge pixels outward by 1px |
+| `--slice <name>` | Export only the area of a named slice |
+| `--oneframe` | Load only the first frame |
+
+---
+
+## Padding (for sprite sheets)
+
+| Flag | Effect |
+|------|--------|
+| `--border-padding <px>` | Padding around the whole sheet |
+| `--shape-padding <px>` | Gap between frames |
+| `--inner-padding <px>` | Padding inside each frame border |
+
+---
+
+## Scripting
+
+```sh
+# Run a Lua script
+aseprite --batch --script my_script.lua
+
+# Pass parameters to the script
+aseprite --batch sprite.aseprite --script process.lua --script-param key=value
+```
+
+In the Lua script, read params via `app.params["key"]`.
+
+The `--shell` flag opens an interactive Lua REPL (not useful in CI).
+
+---
+
+## Introspection
+
+```sh
+# List layers (also adds to JSON if --data is present)
+aseprite --batch sprite.aseprite --list-layers
+
+# List tags with frame ranges
+aseprite --batch sprite.aseprite --list-tags
+
+# List slices
+aseprite --batch sprite.aseprite --list-slices
+
+# List layers with group hierarchy
+aseprite --batch sprite.aseprite --list-layer-hierarchy
+```
+
+---
+
+## Wasteland Racer Pipeline
+
+```sh
+# Export a sprite to PNG (used by make export-sprites)
+aseprite --batch assets/sprites/<name>.aseprite --save-as assets/sprites/<name>.png
+
+# Batch-export all sprites
+make export-sprites
+```
+
+PNG requirements for `png_to_tiles.py` downstream:
+- Indexed color (color type 3), 4-color palette, dimensions multiples of 8
+- Do **not** pass `--color-mode` unless you need to force conversion
+
+---
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| `--export-type png` | Not a valid flag — use `--save-as file.png` |
+| Omitting `--batch` | GUI launches; script hangs |
+| Filters after `--save-as` | Filters must come *before* `--save-as` / `--sheet` |
+| `--split-tags` after input | `--split-layers` / `--split-tags` must precede the input filename |
+| Expecting single PNG for multi-frame | Aseprite auto-appends frame numbers; use `--oneframe` if you want frame 0 only |
+
+---
+
+## Cross-References
+
+- **`sprite-expert`** — Wasteland Racer sprite pipeline, OAM API, indexed palette setup
+- **`map-expert`** — Background tileset export pipeline

--- a/.claude/skills/sprite-builder/SKILL.md
+++ b/.claude/skills/sprite-builder/SKILL.md
@@ -11,6 +11,8 @@ Step-by-step guide to add a new sprite from scratch. Uses the Aseprite → `png_
 
 **REQUIRED BACKGROUND:** Invoke the `sprite-expert` skill before writing any code — it has the full API reference, OAM coordinate math, palette setup, and VBlank rules.
 
+**REQUIRED — Aseprite CLI:** ALWAYS invoke the **`aseprite`** skill before running any `aseprite` command. It has the complete flag reference and prevents common mistakes.
+
 ---
 
 ## Quick Checklist
@@ -188,5 +190,6 @@ Check:
 ## Cross-References
 
 - **`sprite-expert`** — Full API reference, coordinate system details, pool internals, CGB palette registers
+- **`aseprite`** — Full Aseprite CLI reference: all flags, sprite sheet export, scripting, filtering
 - **`gbdk-expert`** — OAM hardware, PPU modes, VBlank timing, LCDC register
 - **`map-expert`** — Background tile pipeline (BG tiles are separate from sprite tiles)

--- a/.claude/skills/sprite-expert/SKILL.md
+++ b/.claude/skills/sprite-expert/SKILL.md
@@ -50,6 +50,8 @@ aseprite --batch assets/sprites/<name>.aseprite --save-as assets/sprites/<name>.
 ```
 Note: `--export-type` is NOT a valid flag. Use `--save-as` with a `.png` extension.
 
+**REQUIRED — Aseprite CLI:** ALWAYS invoke the **`aseprite`** skill before running any `aseprite` command. It has the complete flag reference and prevents common mistakes (e.g., `--export-type` is not a valid flag).
+
 **Run tests after any converter change:**
 ```sh
 python3 -m unittest discover -s tests -p "test_png_to_tiles.py" -v
@@ -185,5 +187,6 @@ set_sprite_data(0, n, tile_data_array);   /* VRAM write — safe in VBlank */
 
 ## Cross-References
 
+- **`aseprite`** — Full Aseprite CLI reference: all flags, sprite sheet options, scripting, layer/tag filtering
 - **`gbdk-expert`** — OAM hardware registers, PPU modes, CGB palette registers, VBlank timing details
 - **`map-expert`** — Tiled map/tileset format; tile data pipeline for background tiles (not sprites)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Always use `gh` for git push/pull and GitHub operations. Run `gh auth setup-git`
 - **`gb-c-optimizer`** — C code review for GBC performance/ROM size, anti-pattern detection, SDCC optimization.
 - **`/map-expert`** — Map pipeline: Tiled TMX format, Python converters (`tmx_to_c`, `png_to_tiles`), GB BG tilemap hardware. Use when creating or modifying maps. **Update this skill in the same PR** whenever the pipeline changes.
 - **`/sprite-expert`** — Sprite pipeline: Aseprite authoring, `png_to_tiles.py`, sprite pool, OAM API, CGB palette for sprites, coordinate system. Use when creating or modifying sprites. **Update this skill in the same PR** whenever the sprite system changes.
+- **`/aseprite`** — Aseprite CLI reference: all `--batch` flags, sprite sheet export, layer/tag filtering, color mode conversion, scripting. **ALWAYS invoke before running any `aseprite` command.**
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Adds new `/aseprite` skill — complete Aseprite CLI reference sourced from https://www.aseprite.org/docs/cli/
- Covers: `--batch` mode, `--save-as`, sprite sheet generation, layer/tag/frame filtering, filename format variables, color mode conversion, scripting (`--script`, `--script-param`), padding, introspection flags, and Wasteland Racer pipeline notes
- Updates `sprite-expert` and `sprite-builder` to **ALWAYS invoke `/aseprite`** before running any `aseprite` command
- Adds `/aseprite` entry to `CLAUDE.md` specialized agents section

## Test plan

- [ ] Invoke `/aseprite` skill and verify flag reference is complete and accurate
- [ ] Export a sprite via `aseprite --batch ... --save-as` and confirm correct flag is used (not `--export-type`)
- [ ] Verify `sprite-builder` skill shows REQUIRED aseprite invocation in its overview

🤖 Generated with [Claude Code](https://claude.com/claude-code)