### PR TITLE
chore: rename project to Junk Runner

### DIFF
--- a/.claude/agents/gb-c-optimizer.md
+++ b/.claude/agents/gb-c-optimizer.md
@@ -8,13 +8,13 @@ You are a C optimizer specialist for GBDK-2020 targeting the Game Boy Color (Z80
 
 ## Project Context
 - **Toolchain:** `/home/mathdaman/gbdk/bin/lcc` (wraps SDCC)
-- **Compiler flags:** `-Wa-l -Wl-m -Wl-j -Wm-yc -Wm-yt1 -Wm-yn"WSTLND RACER"`
-- **Output:** `build/wasteland-racer.gb`
+- **Compiler flags:** `-Wa-l -Wl-m -Wl-j -Wm-yc -Wm-yt1 -Wm-yn"JUNK RUNNER"`
+- **Output:** `build/junk-runner.gb`
 - **Source:** `src/*.c`
 
 ## Memory Behavior
 At the start of every review, read your memory file:
-`~/.claude/projects/-home-mathdaman-code-gmb-wasteland-racer/memory/gb-c-optimizer.md`
+`~/.claude/projects/-home-mathdaman-code-gmb-junk-runner/memory/gb-c-optimizer.md`
 
 After each review, append confirmed anti-patterns and their fixes to that file. Do not duplicate existing entries.
 
@@ -43,7 +43,7 @@ After each review, append confirmed anti-patterns and their fixes to that file. 
 - Tile/sprite data as `const uint8_t[]` with `BANKREF` annotation for bank placement
 
 ### ROM/RAM Size Tips
-- Check sizes with: `ls -la build/wasteland-racer.gb`
+- Check sizes with: `ls -la build/junk-runner.gb`
 - Object map via `-Wl-m` flag (already in CFLAGS) — check `build/*.map`
 - Strip debug: ensure no `-debug` flag in LCC invocation for release builds
 

--- a/.claude/agents/gbdk-expert.md
+++ b/.claude/agents/gbdk-expert.md
@@ -4,17 +4,17 @@ description: Use this agent for GBDK-2020 API questions, Game Boy hardware regis
 color: cyan
 ---
 
-You are a GBDK-2020 expert for the Wasteland Racer Game Boy Color game.
+You are a GBDK-2020 expert for the Junk Runner Game Boy Color game.
 
 ## Project Context
-- **ROM title:** WSTLND RACER
+- **ROM title:** JUNK RUNNER
 - **Hardware target:** CGB compatible (`-Wm-yc`), MBC1 (`-Wm-yt1`)
-- **Build:** `GBDK_HOME=/home/mathdaman/gbdk make`, output `build/wasteland-racer.gb`
+- **Build:** `GBDK_HOME=/home/mathdaman/gbdk make`, output `build/junk-runner.gb`
 - **Source:** `src/*.c`
 
 ## Memory Behavior
 At the start of every task, read your memory file:
-`~/.claude/projects/-home-mathdaman-code-gmb-wasteland-racer/memory/gbdk-expert.md`
+`~/.claude/projects/-home-mathdaman-code-gmb-junk-runner/memory/gbdk-expert.md`
 
 After completing a task, append any new bugs found, API gotchas, or confirmed patterns to that file. Do not duplicate existing entries.
 

--- a/.claude/agents/map-builder.md
+++ b/.claude/agents/map-builder.md
@@ -1,22 +1,22 @@
 ---
 name: map-builder
-description: Use this agent when creating a new map or track for Wasteland Racer — designing a layout in Tiled, running the TMX conversion pipeline, wiring generated C files into the game, or extending the tileset. Examples: "create a new desert track", "add a new map layout", "design a second level".
+description: Use this agent when creating a new map or track for Junk Runner — designing a layout in Tiled, running the TMX conversion pipeline, wiring generated C files into the game, or extending the tileset. Examples: "create a new desert track", "add a new map layout", "design a second level".
 color: green
 ---
 
-You are a map creation specialist for the Wasteland Racer Game Boy Color game. You execute the end-to-end map creation workflow. Use the `map-expert` skill for all pipeline details, API reference, GID math, and hardware constraints — don't reproduce that knowledge here, look it up when needed.
+You are a map creation specialist for the Junk Runner Game Boy Color game. You execute the end-to-end map creation workflow. Use the `map-expert` skill for all pipeline details, API reference, GID math, and hardware constraints — don't reproduce that knowledge here, look it up when needed.
 
 ## Project Context
 
 - **Map pipeline:** `assets/maps/<name>.aseprite` → PNG → `tools/png_to_tiles.py` → `src/<name>_tiles.c`
   and: `assets/maps/<name>.tmx` → `tools/tmx_to_c.py` → `src/<name>_map.c`
 - **Current map dimensions:** 40×36 tiles (`MAP_TILES_W` / `MAP_TILES_H` in `src/config.h`)
-- **Build:** `GBDK_HOME=/home/mathdaman/gbdk make` → `build/wasteland-racer.gb`
+- **Build:** `GBDK_HOME=/home/mathdaman/gbdk make` → `build/junk-runner.gb`
 
 ## Memory Behavior
 
 At the start of every task, read:
-`~/.claude/projects/-home-mathdaman-code-gmb-wasteland-racer/memory/map-expert.md`
+`~/.claude/projects/-home-mathdaman-code-gmb-junk-runner/memory/map-expert.md`
 
 After completing a task, append new pipeline gotchas or confirmed patterns. Do not duplicate existing entries.
 

--- a/.claude/agents/sprite-builder.md
+++ b/.claude/agents/sprite-builder.md
@@ -1,21 +1,21 @@
 ---
 name: sprite-builder
-description: Use this agent when adding a new sprite type to Wasteland Racer — creating the Aseprite source, exporting PNG, running png_to_tiles, allocating OAM slots, loading tile data, and rendering the sprite in game. Examples: "add an enemy car sprite", "create a new HUD icon", "add an explosion sprite".
+description: Use this agent when adding a new sprite type to Junk Runner — creating the Aseprite source, exporting PNG, running png_to_tiles, allocating OAM slots, loading tile data, and rendering the sprite in game. Examples: "add an enemy car sprite", "create a new HUD icon", "add an explosion sprite".
 color: orange
 ---
 
-You are a sprite creation specialist for the Wasteland Racer Game Boy Color game. You execute the end-to-end sprite creation workflow. Use the `sprite-expert` skill for all API names, coordinate math, OAM pool internals, palette setup, and VBlank rules — don't reproduce that knowledge here, look it up when needed.
+You are a sprite creation specialist for the Junk Runner Game Boy Color game. You execute the end-to-end sprite creation workflow. Use the `sprite-expert` skill for all API names, coordinate math, OAM pool internals, palette setup, and VBlank rules — don't reproduce that knowledge here, look it up when needed.
 
 ## Project Context
 
 - **Sprite pipeline:** `assets/sprites/<name>.aseprite` → `make export-sprites` → `assets/sprites/<name>.png` → `tools/png_to_tiles.py` → `src/<name>_sprite.c`
 - **OAM budget:** 40 total slots — player uses 2; remaining 38 for enemies, projectiles, HUD
-- **Build:** `GBDK_HOME=/home/mathdaman/gbdk make` → `build/wasteland-racer.gb`
+- **Build:** `GBDK_HOME=/home/mathdaman/gbdk make` → `build/junk-runner.gb`
 
 ## Memory Behavior
 
 At the start of every task, read:
-`~/.claude/projects/-home-mathdaman-code-gmb-wasteland-racer/memory/sprite-expert.md`
+`~/.claude/projects/-home-mathdaman-code-gmb-junk-runner/memory/sprite-expert.md`
 
 After completing a task, append new API gotchas, coordinate bugs, or confirmed patterns. Do not duplicate existing entries.
 

--- a/.claude/skills/aseprite/SKILL.md
+++ b/.claude/skills/aseprite/SKILL.md
@@ -190,7 +190,7 @@ aseprite --batch sprite.aseprite --list-layer-hierarchy
 
 ---
 
-## Wasteland Racer Pipeline
+## Junk Runner Pipeline
 
 ```sh
 # Export a sprite to PNG (used by make export-sprites)
@@ -220,5 +220,5 @@ PNG requirements for `png_to_tiles.py` downstream:
 
 ## Cross-References
 
-- **`sprite-expert`** — Wasteland Racer sprite pipeline, OAM API, indexed palette setup
+- **`sprite-expert`** — Junk Runner sprite pipeline, OAM API, indexed palette setup
 - **`map-expert`** — Background tileset export pipeline

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -5,7 +5,7 @@ description: Use this skill to build the GBC ROM. Triggers when verifying a buil
 
 Run `GBDK_HOME=/home/mathdaman/gbdk make`.
 
-On success: report ROM size with `ls -lh build/wasteland-racer.gb`.
+On success: report ROM size with `ls -lh build/junk-runner.gb`.
 
 On failure: extract lines containing "error:" from the output, show each as
 `file:line: message`. Distinguish compiler errors (fixable in source) from

--- a/.claude/skills/emulicious-debug/SKILL.md
+++ b/.claude/skills/emulicious-debug/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: emulicious-debug
-description: Use when debugging the Wasteland Racer ROM in Emulicious — EMU_printf output, step-through debugging, breakpoints, memory/tile/sprite inspection, tracer, profiler, or romusage analysis.
+description: Use when debugging the Junk Runner ROM in Emulicious — EMU_printf output, step-through debugging, breakpoints, memory/tile/sprite inspection, tracer, profiler, or romusage analysis.
 ---
 
-# Emulicious Debugging — Wasteland Racer
+# Emulicious Debugging — Junk Runner
 
 ## Quick Start
 
 ```sh
 # Run ROM in Emulicious
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb
 ```
 
 **Further reading:**
@@ -64,7 +64,7 @@ EMU_printf("cam_y=%u py=%u\n", cam_y, py);
             "type": "emulicious-debugger",
             "request": "launch",
             "name": "Launch in Emulicious",
-            "program": "${workspaceFolder}/build/wasteland-racer.gb",
+            "program": "${workspaceFolder}/build/junk-runner.gb",
             "port": 58870,
             "stopOnEntry": true
         }
@@ -127,7 +127,7 @@ Useful for: confirming which code path runs, finding dead code, verifying interr
 Included with GBDK-2020. Run after build to check space usage:
 
 ```sh
-romusage build/wasteland-racer.gb -g
+romusage build/junk-runner.gb -g
 ```
 
 **Common flags:**
@@ -142,7 +142,7 @@ romusage build/wasteland-racer.gb -g
 
 For full symbol breakdown, build with `-debug` to generate `.cdb` file, then:
 ```sh
-romusage build/wasteland-racer.cdb -a
+romusage build/junk-runner.cdb -a
 ```
 
 ---
@@ -150,7 +150,7 @@ romusage build/wasteland-racer.cdb -a
 ## Workflow: Debugging a Bug
 
 1. Add `EMU_printf` at the suspect location, rebuild (`/build`)
-2. Launch: `java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb`
+2. Launch: `java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb`
 3. Observe console output; narrow the problem
 4. Set VS Code breakpoints at suspect line; use Step Over/Into to inspect variables
 5. Use Tilemap/Sprite Viewers to confirm visual state matches logic

--- a/.claude/skills/gbdk-expert/SKILL.md
+++ b/.claude/skills/gbdk-expert/SKILL.md
@@ -3,11 +3,11 @@ name: gbdk-expert
 description: Use when writing or reviewing GBDK-2020 code — API calls, hardware registers, sprite/tile/palette setup, VBlank timing, CGB color palettes, interrupt handling, MBC banking, or GBDK compilation errors. Use during planning to verify API names and constraints before writing tests.
 ---
 
-# GBDK Expert — Wasteland Racer
+# GBDK Expert — Junk Runner
 
 ## Memory
 At the start of any GBDK-related task, read:
-`~/.claude/projects/-home-mathdaman-code-gmb-wasteland-racer/memory/gbdk-expert.md`
+`~/.claude/projects/-home-mathdaman-code-gmb-junk-runner/memory/gbdk-expert.md`
 
 After completing the task, append any new bugs, API gotchas, or confirmed patterns to that file. Do not duplicate existing entries.
 

--- a/.claude/skills/map-builder/SKILL.md
+++ b/.claude/skills/map-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: map-builder
-description: Use when creating a new map or track for Wasteland Racer — designing the layout, drawing in Tiled, running the TMX conversion pipeline, and wiring the generated C files into the game.
+description: Use when creating a new map or track for Junk Runner — designing the layout, drawing in Tiled, running the TMX conversion pipeline, and wiring the generated C files into the game.
 ---
 
 # Map Builder
@@ -125,7 +125,7 @@ Wrap tile data load similarly if `track_tile_data` is in a banked file.
 
 ```sh
 GBDK_HOME=/home/mathdaman/gbdk make
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb
 ```
 
 Check:

--- a/.claude/skills/map-expert/SKILL.md
+++ b/.claude/skills/map-expert/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: map-expert
-description: Use when creating, editing, or converting maps for Wasteland Racer — Tiled TMX format, GID decoding, Python pipeline (tmx_to_c, png_to_tiles, gen_tileset), or GB background tilemap hardware (BG tile maps, SCX/SCY, VRAM layout, CGB attributes).
+description: Use when creating, editing, or converting maps for Junk Runner — Tiled TMX format, GID decoding, Python pipeline (tmx_to_c, png_to_tiles, gen_tileset), or GB background tilemap hardware (BG tile maps, SCX/SCY, VRAM layout, CGB attributes).
 ---
 
 # Map Expert
 
 ## Overview
 
-Full reference for the Wasteland Racer map pipeline: Tiled authoring → Python conversion → GB hardware rendering.
+Full reference for the Junk Runner map pipeline: Tiled authoring → Python conversion → GB hardware rendering.
 
 **Keep this skill current:** When you modify any tool in `tools/` or `assets/maps/`, add a new map tool, change the TMX schema, or add GB tilemap features — update the relevant section of this skill in the same PR. The skill is the source of truth for the pipeline.
 

--- a/.claude/skills/music-expert/SKILL.md
+++ b/.claude/skills/music-expert/SKILL.md
@@ -1,6 +1,6 @@
-# Music Expert — Wasteland Racer
+# Music Expert — Junk Runner
 
-Use when working with hUGEDriver music integration, song data, APU registers, or audio for the Wasteland Racer GBC project.
+Use when working with hUGEDriver music integration, song data, APU registers, or audio for the Junk Runner GBC project.
 
 ---
 

--- a/.claude/skills/sprite-builder/SKILL.md
+++ b/.claude/skills/sprite-builder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sprite-builder
-description: Use when adding a new sprite type to Wasteland Racer — creating the Aseprite source, exporting PNG, running png_to_tiles, allocating OAM slots, loading tile data, and rendering the sprite in game.
+description: Use when adding a new sprite type to Junk Runner — creating the Aseprite source, exporting PNG, running png_to_tiles, allocating OAM slots, loading tile data, and rendering the sprite in game.
 ---
 
 # Sprite Builder
@@ -161,7 +161,7 @@ Document the OAM layout comment at the top of `config.h` so the budget stays aud
 
 ```sh
 GBDK_HOME=/home/mathdaman/gbdk make
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb
 ```
 
 Check:

--- a/.claude/skills/sprite-expert/SKILL.md
+++ b/.claude/skills/sprite-expert/SKILL.md
@@ -3,7 +3,7 @@ name: sprite-expert
 description: Use when creating sprites, editing sprite assets, changing how sprites are loaded or rendered, adding new sprite types, modifying the sprite pool, changing OAM slot assignments, updating sprite tile data, or working with the Aseprite pipeline or png_to_tiles converter.
 ---
 
-# Sprite Expert — Wasteland Racer
+# Sprite Expert — Junk Runner
 
 **Update this skill whenever the sprite system changes** (new pipeline steps, new API usage, pool budget changes, coordinate system corrections).
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Upload ROM artifact
         uses: actions/upload-artifact@v4
         with:
-          name: wasteland-racer-${{ github.sha }}
-          path: build/wasteland-racer.gb
+          name: junk-runner-${{ github.sha }}
+          path: build/junk-runner.gb
           if-no-files-found: error

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,10 @@ GBDK_HOME=/home/mathdaman/gbdk make
 make clean
 
 # Run in emulator
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb
 ```
 
-Output ROM: `build/wasteland-racer.gb`
+Output ROM: `build/junk-runner.gb`
 
 ## Architecture
 
@@ -64,7 +64,7 @@ These apply to every feature, no matter how small.
 
 ## ROM Header
 
-Current flags: `-Wm-yc` (CGB compatible, runs on DMG+GBC), `-Wm-yt1` (MBC1), `-Wm-yn"WSTLND RACER"`.
+Current flags: `-Wm-yc` (CGB compatible, runs on DMG+GBC), `-Wm-yt1` (MBC1), `-Wm-yn"JUNK RUNNER"`.
 To target GBC-only (access extra VRAM bank, 8 BG/OBJ palettes): swap `-Wm-yc` for `-Wm-yC`.
 
 ## ROM Banking — Autobanking Conventions
@@ -151,7 +151,7 @@ This project uses [Superpowers](https://github.com/obra/superpowers) (installed 
 **Smoketest gate:** NEVER push or create a PR before running a smoketest in the emulator. Always push AFTER the smoketest passes.
 1. Fetch and merge latest master: `git fetch origin && git merge origin/master` (from the worktree directory). NEVER use `git merge master` alone — the local master ref may be stale.
 2. Rebuild: `GBDK_HOME=/home/mathdaman/gbdk make`
-3. Launch the ROM — do NOT ask permission, just run it immediately in the background: `java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb` (run from the worktree directory so the path resolves to the worktree's `build/`). NEVER launch from the main repo's `build/` — it may be stale.
+3. Launch the ROM — do NOT ask permission, just run it immediately in the background: `java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb` (run from the worktree directory so the path resolves to the worktree's `build/`). NEVER launch from the main repo's `build/` — it may be stale.
 4. Tell the user it's running and ask them to confirm it looks correct before proceeding.
 5. Only after the user confirms: push the branch and create the PR.
 **Branch policy:** NEVER commit directly to `master`. All work goes on a feature branch and merges via PR.

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,9 @@ CFLAGS    := -Wa-l -Wl-m -Wl-j -Wm-ya4 -autobank -Wb-ext=.rel -Ilib/hUGEDriver/i
 ifeq ($(DEBUG),1)
 CFLAGS += -DDEBUG
 endif
-ROMFLAGS  := -Wm-yc -Wm-yt1 -Wm-yn"WSTLND RACER"
+ROMFLAGS  := -Wm-yc -Wm-yt1 -Wm-yn"JUNK RUNNER"
 
-TARGET    := build/wasteland-racer.gb
+TARGET    := build/junk-runner.gb
 OBJ_DIR   := build/obj
 
 SRCS      := $(wildcard src/*.c)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wasteland Racer
+# Junk Runner
 
 A Game Boy Color (GBC) top-down racing game built with [GBDK-2020](https://github.com/gbdk-2020/gbdk-2020).
 
@@ -15,7 +15,7 @@ A Game Boy Color (GBC) top-down racing game built with [GBDK-2020](https://githu
 GBDK_HOME=~/gbdk make
 ```
 
-Output: `build/wasteland-racer.gb`
+Output: `build/junk-runner.gb`
 
 ### Clean
 
@@ -34,10 +34,10 @@ make test
 ## Running
 
 ```sh
-java -jar ~/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
+java -jar ~/.local/share/emulicious/Emulicious.jar build/junk-runner.gb
 ```
 
-Or load `build/wasteland-racer.gb` in any GB/GBC emulator ([Emulicious](https://emulicious.net/), [SameBoy](https://sameboy.github.io/), [BGB](https://bgb.bircd.org/)).
+Or load `build/junk-runner.gb` in any GB/GBC emulator ([Emulicious](https://emulicious.net/), [SameBoy](https://sameboy.github.io/), [BGB](https://bgb.bircd.org/)).
 
 ## Game Modules
 
@@ -95,7 +95,7 @@ setup and export settings.
 ## Project Structure
 
 ```
-gmb-wasteland-racer/
+gmb-junk-runner/
 ├── src/
 │   ├── main.c              # Entry point, main loop, game state machine
 │   ├── state_manager.c/.h  # Game state transitions
@@ -163,7 +163,7 @@ gmb-wasteland-racer/
 | `-Wm-yc` | CGB compatible | Runs on DMG and GBC |
 | `-Wm-yC` | CGB only | GBC exclusive (enhanced color) |
 | `-Wm-yt1` | MBC1 | Memory bank controller type |
-| `-Wm-yn"WSTLND RACER"` | ROM title | 11-char header string |
+| `-Wm-yn"JUNK RUNNER"` | ROM title | 11-char header string |
 
 To target GBC-only (for extra VRAM, 8 palettes, etc.) swap `-Wm-yc` for `-Wm-yC` in the Makefile.
 

--- a/docs/asset-pipeline.md
+++ b/docs/asset-pipeline.md
@@ -29,7 +29,7 @@ into the Game Boy ROM.
                  GBDK/SDCC compiler
                          │
                          ▼
-              build/wasteland-racer.gb
+              build/junk-runner.gb
 ```
 
 Generated `.c` files and exported `.png` files are **checked into git** so CI
@@ -81,7 +81,7 @@ Each 8×8 tile is encoded as 16 bytes of GB 2bpp:
 3. Run `make` to regenerate `src/track_tiles.c`.
 4. In Tiled, add the new tile index to `assets/maps/track.tsx` and use it in `track.tmx`.
 5. Run `make` again to regenerate `src/track_map.c`.
-6. Verify in Emulicious: `java -jar ~/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb`.
+6. Verify in Emulicious: `java -jar ~/.local/share/emulicious/Emulicious.jar build/junk-runner.gb`.
 
 ---
 

--- a/docs/plans/2026-03-10-autobanking.md
+++ b/docs/plans/2026-03-10-autobanking.md
@@ -100,7 +100,7 @@ Expected: all 26 tests PASS (banking macros are no-ops in mock).
 ```
 GBDK_HOME=/home/mathdaman/gbdk make
 ```
-Expected: `build/wasteland-racer.gb` produced with no errors. The flags will now pass through lcc but since no file has `#pragma bank 255` yet, nothing is banked yet.
+Expected: `build/junk-runner.gb` produced with no errors. The flags will now pass through lcc but since no file has `#pragma bank 255` yet, nothing is banked yet.
 
 ### Step 6: Commit
 
@@ -216,7 +216,7 @@ Expected: all 26 tests PASS (`BANKED` is `#define BANKED` = empty string in mock
 ```
 GBDK_HOME=/home/mathdaman/gbdk make
 ```
-Expected: `build/wasteland-racer.gb` built. Bankpack will assign all `#pragma bank 255` files to banks. No linker errors.
+Expected: `build/junk-runner.gb` built. Bankpack will assign all `#pragma bank 255` files to banks. No linker errors.
 
 ### Step 6: Commit
 
@@ -505,7 +505,7 @@ GBDK_HOME=/home/mathdaman/gbdk make
 ### Step 2: Launch smoketest
 
 ```bash
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb &
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb &
 ```
 
 Tell the user the emulator is running and ask them to confirm:

--- a/docs/plans/2026-03-10-hud-implementation.md
+++ b/docs/plans/2026-03-10-hud-implementation.md
@@ -88,7 +88,7 @@ static uint8_t LCDC_REG = 0x91U; /* realistic boot value: LCD on, BG on, tile da
 **Step 2: Run existing tests to confirm nothing broke**
 
 ```bash
-cd /home/mathdaman/code/gmb-wasteland-racer/.claude/worktrees/feat/hud
+cd /home/mathdaman/code/gmb-junk-runner/.claude/worktrees/feat/hud
 make test 2>&1 | tail -20
 ```
 
@@ -500,7 +500,7 @@ git commit -m "feat: integrate hud_init/render/update into state_playing"
 GBDK_HOME=/home/mathdaman/gbdk make 2>&1
 ```
 
-Expected: `build/wasteland-racer.gb` produced with zero errors. Warnings about "so said EVELYN" are harmless and expected.
+Expected: `build/junk-runner.gb` produced with zero errors. Warnings about "so said EVELYN" are harmless and expected.
 
 If compile errors appear:
 - `LCDC_REG` / `LCDCF_WIN9C00` undefined → add `#include <gb/hardware.h>` to `hud.c`
@@ -522,7 +522,7 @@ If nothing new, no commit needed here.
 **Step 1: Launch the emulator in the background**
 
 ```bash
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb &
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb &
 ```
 
 **Step 2: Tell the user to confirm the following in the emulator:**

--- a/docs/plans/2026-03-10-hugedriver-music.md
+++ b/docs/plans/2026-03-10-hugedriver-music.md
@@ -105,7 +105,7 @@ $(TARGET): $(OBJS) | build
 ```bash
 GBDK_HOME=/home/mathdaman/gbdk make
 ```
-Expected: `build/wasteland-racer.gb` produced, no errors. The `-I` flag is new but harmless until music headers are included.
+Expected: `build/junk-runner.gb` produced, no errors. The `-I` flag is new but harmless until music headers are included.
 
 **Step 4: Commit**
 
@@ -389,7 +389,7 @@ void main(void) {
 ```bash
 GBDK_HOME=/home/mathdaman/gbdk make 2>&1 | grep -i "error" | grep -v "so said EVELYN"
 ```
-Expected: no errors, `build/wasteland-racer.gb` produced.
+Expected: no errors, `build/junk-runner.gb` produced.
 
 **Step 6: Commit**
 
@@ -405,7 +405,7 @@ git commit -m "feat: wire music_init() and music_tick() into main.c"
 **Step 1: Launch emulator in background**
 
 ```bash
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb &
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb &
 ```
 
 **Step 2: Inform the user**
@@ -421,7 +421,7 @@ Tell the user: "Emulicious is running. Please confirm that music plays and loops
 **Step 1: Push the branch**
 
 ```bash
-gh repo set-default MatthieuGagne/gmb-wasteland-racer
+gh repo set-default MatthieuGagne/gmb-junk-runner
 git push -u origin worktree-feat/hugedriver-music
 ```
 

--- a/docs/plans/2026-03-10-overmap-state.md
+++ b/docs/plans/2026-03-10-overmap-state.md
@@ -757,17 +757,17 @@ Expected: ALL tests PASS.
 ```sh
 GBDK_HOME=/home/mathdaman/gbdk make
 ```
-Expected: `build/wasteland-racer.gb` produced with no errors.
+Expected: `build/junk-runner.gb` produced with no errors.
 
 **Step 3: Launch emulator** (run in background; ask user to verify)
 
 ```sh
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb
 ```
 
 **Verify these scenarios manually:**
 
-1. Title screen shows "WASTELAND RACER / Press START"
+1. Title screen shows "JUNK RUNNER / Press START"
 2. Pressing START shows the overmap — horizontal road with hub center, dest squares at left+right
 3. D-pad left/right moves the car sprite along the road; up/down do nothing
 4. Car cannot move past the dest tiles (screen edge direction is blank)

--- a/docs/plans/2026-03-10-terrain-tile-effects.md
+++ b/docs/plans/2026-03-10-terrain-tile-effects.md
@@ -83,7 +83,7 @@ Expected: all tests pass.
 **Step 3: Commit**
 
 ```bash
-cd /home/mathdaman/code/gmb-wasteland-racer/.worktrees/terrain-effects
+cd /home/mathdaman/code/gmb-junk-runner/.worktrees/terrain-effects
 git add src/config.h
 git commit -m "feat: add terrain constants to config.h (sand friction mul, boost delta)"
 ```
@@ -146,7 +146,7 @@ tile 5 (boost):   horizontal stripes: even rows=0, odd rows=1
 
 ```python
 #!/usr/bin/env python3
-"""Generate the 6-tile Wasteland Racer tileset PNG (48×8, RGB).
+"""Generate the 6-tile Junk Runner tileset PNG (48×8, RGB).
 
 Run: python3 tools/gen_tileset.py assets/maps/tileset.png
 """
@@ -754,12 +754,12 @@ Use the `/build` skill or:
 ```bash
 GBDK_HOME=/home/mathdaman/gbdk make
 ```
-Expected: `build/wasteland-racer.gb` produced, 0 errors (ignore "EVELYN" optimizer notice).
+Expected: `build/junk-runner.gb` produced, 0 errors (ignore "EVELYN" optimizer notice).
 
 **Step 2: Launch smoketest in Emulicious**
 
 ```bash
-java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/wasteland-racer.gb &
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/junk-runner.gb &
 ```
 
 Ask the user to confirm:

--- a/src/state_title.c
+++ b/src/state_title.c
@@ -10,7 +10,7 @@
 static void enter(void) {
     cls();
     gotoxy(2, 6);
-    printf("WASTELAND RACER");
+    printf("JUNK RUNNER");
     gotoxy(3, 10);
     printf("Press START");
 }

--- a/tools/tmx_to_c.py
+++ b/tools/tmx_to_c.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""TMX to C converter for Wasteland Racer track maps.
+"""TMX to C converter for Junk Runner track maps.
 
 Usage: python3 tools/tmx_to_c.py <track.tmx> <track_map.c>
 


### PR DESCRIPTION
## Summary
- Replaces all occurrences of "Wasteland Racer" / "wasteland-racer" / "WSTLND RACER" with "Junk Runner" / "junk-runner" / "JUNK RUNNER"
- Covers source, docs, skills, agents, CI, and Makefile
- ROM output is now `build/junk-runner.gb`

## Test plan
- [x] 27 unit tests passing
- [x] ROM builds cleanly (64K)
- [x] Smoketest confirmed: title screen shows JUNK RUNNER

🤖 Generated with [Claude Code](https://claude.com/claude-code)