### PR TITLE
feat: node-to-node overmap navigation with animation

### DIFF
--- a/src/state_overmap.c
+++ b/src/state_overmap.c
@@ -17,6 +17,14 @@ static uint8_t car_tx;
 static uint8_t car_ty;
 uint8_t current_race_id = 0u;
 
+#define TRAVEL_FRAMES_PER_TILE 4u   /* file-local tuning — not in config.h */
+
+static uint8_t traveling;           /* 0=idle, 1=animating */
+static uint8_t travel_dir;          /* J_LEFT/J_RIGHT/J_UP/J_DOWN bitmask */
+static uint8_t travel_frame_count;  /* counts down to 0 before each tile step */
+static uint8_t dest_tx;
+static uint8_t dest_ty;
+
 uint8_t overmap_get_car_tx(void) { return car_tx; }
 uint8_t overmap_get_car_ty(void) { return car_ty; }
 
@@ -33,10 +41,54 @@ static void overmap_move_sprite(void) {
     move_sprite(1u, sx, (uint8_t)(sy + 8u));
 }
 
+static uint8_t find_next_node(int8_t dx, int8_t dy, uint8_t *out_tx, uint8_t *out_ty) {
+    int8_t cx = (int8_t)car_tx + dx;
+    int8_t cy = (int8_t)car_ty + dy;
+    if (cx < 0 || cy < 0 || cx >= (int8_t)OVERMAP_W || cy >= (int8_t)OVERMAP_H)
+        return 0u;
+    {
+        uint8_t ux = (uint8_t)cx;
+        uint8_t uy = (uint8_t)cy;
+        if (!overmap_walkable(ux, uy)) return 0u;  /* first tile blank -> no move */
+    }
+    while (cx >= 0 && cy >= 0 && cx < (int8_t)OVERMAP_W && cy < (int8_t)OVERMAP_H) {
+        {
+            uint8_t ux = (uint8_t)cx;
+            uint8_t uy = (uint8_t)cy;
+            uint8_t tile = overmap_map[(uint16_t)uy * OVERMAP_W + ux];
+            if (tile != OVERMAP_TILE_ROAD) {
+                *out_tx = ux; *out_ty = uy;
+                return 1u;
+            }
+        }
+        cx += dx; cy += dy;
+    }
+    return 0u;
+}
+
+static void overmap_check_tile_effect(void) {
+    uint8_t tile = overmap_map[(uint16_t)car_ty * OVERMAP_W + car_tx];
+    if (tile == OVERMAP_TILE_CITY_HUB) {
+        traveling = 0u;               /* clear BEFORE state_push — no reset needed on pop */
+        state_push(&state_hub);
+        overmap_hub_entered = 1u;
+        return;
+    }
+    if (tile == OVERMAP_TILE_DEST) {
+        traveling = 0u;
+        current_race_id = (car_tx < OVERMAP_HUB_TX) ? 0u : 1u;
+        player_set_pos(track_start_x, track_start_y);
+        player_reset_vel();
+        state_replace(&state_playing);
+    }
+}
+
 /* ── State callbacks ─────────────────────────────────────────────────────────── */
 static void enter(void) {
     car_tx = OVERMAP_HUB_TX;
     car_ty = OVERMAP_HUB_TY;
+    traveling = 0u; travel_dir = 0u; travel_frame_count = 0u;
+    dest_tx = 0u;   dest_ty = 0u;
 
     wait_vbl_done();
     DISPLAY_OFF;
@@ -54,33 +106,40 @@ static void enter(void) {
 }
 
 static void update(void) {
-    uint8_t new_tx = car_tx;
-    uint8_t new_ty = car_ty;
-
-    if      (KEY_TICKED(J_LEFT)  && car_tx > 0u)             new_tx = car_tx - 1u;
-    else if (KEY_TICKED(J_RIGHT) && car_tx < OVERMAP_W - 1u) new_tx = car_tx + 1u;
-    else if (KEY_TICKED(J_UP)    && car_ty > 0u)             new_ty = car_ty - 1u;
-    else if (KEY_TICKED(J_DOWN)  && car_ty < OVERMAP_H - 1u) new_ty = car_ty + 1u;
-
-    if (new_tx == car_tx && new_ty == car_ty) return;
-    if (!overmap_walkable(new_tx, new_ty))    return;
-
-    car_tx = new_tx;
-    car_ty = new_ty;
-    overmap_move_sprite();
-
-    {
-        uint8_t tile = overmap_map[(uint16_t)car_ty * OVERMAP_W + car_tx];
-        if (tile == OVERMAP_TILE_CITY_HUB) {
-            state_push(&state_hub);
-            overmap_hub_entered = 1u;  /* set after enter() so hub can clear on re-entry */
+    if (traveling) {
+        if (travel_frame_count > 0u) { travel_frame_count--; return; }
+        if      (travel_dir == J_LEFT  && car_tx > 0u)             car_tx--;
+        else if (travel_dir == J_RIGHT && car_tx < OVERMAP_W - 1u) car_tx++;
+        else if (travel_dir == J_UP    && car_ty > 0u)             car_ty--;
+        else if (travel_dir == J_DOWN  && car_ty < OVERMAP_H - 1u) car_ty++;
+        overmap_move_sprite();
+        if (car_tx == dest_tx && car_ty == dest_ty) {
+            traveling = 0u;
+            overmap_check_tile_effect();
             return;
         }
-        if (tile == OVERMAP_TILE_DEST) {
-            current_race_id = (car_tx < OVERMAP_HUB_TX) ? 0u : 1u;
-            player_set_pos(track_start_x, track_start_y);
-            player_reset_vel();
-            state_replace(&state_playing);
+        travel_frame_count = TRAVEL_FRAMES_PER_TILE - 1u;
+        return;
+    }
+    if (KEY_TICKED(J_LEFT)) {
+        if (find_next_node(-1, 0, &dest_tx, &dest_ty)) {
+            traveling = 1u; travel_dir = J_LEFT;
+            travel_frame_count = TRAVEL_FRAMES_PER_TILE - 1u;
+        }
+    } else if (KEY_TICKED(J_RIGHT)) {
+        if (find_next_node(1, 0, &dest_tx, &dest_ty)) {
+            traveling = 1u; travel_dir = J_RIGHT;
+            travel_frame_count = TRAVEL_FRAMES_PER_TILE - 1u;
+        }
+    } else if (KEY_TICKED(J_UP)) {
+        if (find_next_node(0, -1, &dest_tx, &dest_ty)) {
+            traveling = 1u; travel_dir = J_UP;
+            travel_frame_count = TRAVEL_FRAMES_PER_TILE - 1u;
+        }
+    } else if (KEY_TICKED(J_DOWN)) {
+        if (find_next_node(0, 1, &dest_tx, &dest_ty)) {
+            traveling = 1u; travel_dir = J_DOWN;
+            travel_frame_count = TRAVEL_FRAMES_PER_TILE - 1u;
         }
     }
 }

--- a/tests/test_overmap.c
+++ b/tests/test_overmap.c
@@ -15,6 +15,15 @@ static void tick(uint8_t btn) {
     input = 0;
 }
 
+/* Helper: arm travel with one press, then run 80 frames to complete */
+static void travel_to_node(uint8_t btn) {
+    uint8_t i;
+    prev_input = 0; input = btn;
+    state_overmap.update();
+    prev_input = input; input = 0;
+    for (i = 0u; i < 80u; i++) { state_overmap.update(); }
+}
+
 void setUp(void) {
     input = 0;
     prev_input = 0;
@@ -28,21 +37,21 @@ void test_car_starts_at_hub(void) {
     TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TY, overmap_get_car_ty());
 }
 
-void test_left_moves_onto_road(void) {
-    tick(J_LEFT);
-    TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TX - 1u, overmap_get_car_tx());
-    TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TY,      overmap_get_car_ty());
+void test_left_travels_to_dest(void) {
+    travel_to_node(J_LEFT);
+    TEST_ASSERT_EQUAL_UINT8(OVERMAP_DEST_LEFT_TX, overmap_get_car_tx());
 }
 
-void test_right_moves_onto_road(void) {
-    tick(J_RIGHT);
-    TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TX + 1u, overmap_get_car_tx());
+void test_right_travels_to_dest(void) {
+    travel_to_node(J_RIGHT);
+    TEST_ASSERT_EQUAL_UINT8(OVERMAP_DEST_RIGHT_TX, overmap_get_car_tx());
 }
 
-void test_up_moves_onto_road_tile(void) {
-    /* Row 7 col 9 is now a road tile — moving up from spawn must succeed */
-    tick(J_UP);
-    TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TY - 1u, overmap_get_car_ty());
+void test_up_travels_to_city_hub(void) {
+    travel_to_node(J_UP);
+    /* city hub tile is at (9,6) — arrives at (9,6) which triggers hub entry */
+    /* car_ty should be OVERMAP_HUB_TY - 2u = 6 */
+    TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TY - 2u, overmap_get_car_ty());
 }
 
 void test_down_blocked_by_blank(void) {
@@ -59,52 +68,59 @@ void test_held_button_does_not_repeat(void) {
 }
 
 void test_dest_left_sets_race_id(void) {
-    /* Walk left from hub (tx=9) to dest (tx=2): 7 ticks */
-    uint8_t moves = OVERMAP_HUB_TX - OVERMAP_DEST_LEFT_TX;
-    uint8_t i;
-    for (i = 0; i < moves; i++) {
-        tick(J_LEFT);
-    }
+    travel_to_node(J_LEFT);
     TEST_ASSERT_EQUAL_UINT8(0u, current_race_id);
 }
 
 void test_dest_right_sets_race_id(void) {
-    uint8_t moves = OVERMAP_DEST_RIGHT_TX - OVERMAP_HUB_TX;
-    uint8_t i;
-    for (i = 0; i < moves; i++) {
-        tick(J_RIGHT);
-    }
+    travel_to_node(J_RIGHT);
     TEST_ASSERT_EQUAL_UINT8(1u, current_race_id);
 }
 
 void test_city_hub_tile_triggers_hub_entry(void) {
-    /* City hub building is at (9, 6) — two moves north from spawn. */
     overmap_hub_entered = 0u;
-    tick(J_UP);  /* (9,8) → (9,7) road */
-    TEST_ASSERT_EQUAL_UINT8(0u, overmap_hub_entered);  /* road: no trigger yet */
-    tick(J_UP);  /* (9,7) → (9,6) city hub */
+    travel_to_node(J_UP);
     TEST_ASSERT_EQUAL_UINT8(1u, overmap_hub_entered);
 }
 
 void test_city_hub_tile_car_position_unchanged_after_enter(void) {
-    /* Car should stay at (9,6) after entering hub */
-    tick(J_UP);
-    tick(J_UP);
+    travel_to_node(J_UP);
     TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TX,      overmap_get_car_tx());
     TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TY - 2u, overmap_get_car_ty());
+}
+
+void test_input_ignored_while_traveling(void) {
+    uint8_t i;
+    prev_input = 0; input = J_LEFT; state_overmap.update();  /* arm travel */
+    prev_input = 0; input = J_RIGHT; state_overmap.update(); /* mid-travel: ignored */
+    prev_input = input; input = 0;
+    for (i = 0u; i < 80u; i++) { state_overmap.update(); }
+    TEST_ASSERT_EQUAL_UINT8(OVERMAP_DEST_LEFT_TX, overmap_get_car_tx());
+}
+
+void test_travel_advances_one_tile_per_four_frames(void) {
+    uint8_t i;
+    prev_input = 0; input = J_LEFT; state_overmap.update();
+    prev_input = input; input = 0;
+    for (i = 0u; i < 3u; i++) state_overmap.update();
+    TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TX, overmap_get_car_tx());      /* no move at frame 3 */
+    state_overmap.update();
+    TEST_ASSERT_EQUAL_UINT8(OVERMAP_HUB_TX - 1u, overmap_get_car_tx()); /* moved at frame 4 */
 }
 
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_car_starts_at_hub);
-    RUN_TEST(test_left_moves_onto_road);
-    RUN_TEST(test_right_moves_onto_road);
-    RUN_TEST(test_up_moves_onto_road_tile);
+    RUN_TEST(test_left_travels_to_dest);
+    RUN_TEST(test_right_travels_to_dest);
+    RUN_TEST(test_up_travels_to_city_hub);
     RUN_TEST(test_down_blocked_by_blank);
     RUN_TEST(test_held_button_does_not_repeat);
     RUN_TEST(test_dest_left_sets_race_id);
     RUN_TEST(test_dest_right_sets_race_id);
     RUN_TEST(test_city_hub_tile_triggers_hub_entry);
     RUN_TEST(test_city_hub_tile_car_position_unchanged_after_enter);
+    RUN_TEST(test_input_ignored_while_traveling);
+    RUN_TEST(test_travel_advances_one_tile_per_four_frames);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Replace tile-by-tile overmap movement with single-press node-to-node travel
- Car animates at 1 tile per 4 frames to the next DEST or CITY_HUB along the road
- Input is ignored while traveling (no direction changes mid-travel)

## Test Plan
- [x] 12 overmap unit tests pass (10 rewritten for node arrival, 2 new: input-ignored-while-traveling, travel-advances-one-tile-per-four-frames)
- [x] Clean ROM build (64K)
- [x] Memory validator: ROM/WRAM/VRAM PASS, OAM WARN (pre-existing, 40/40 slots)
- [x] Smoketest: LEFT/RIGHT/UP from hub all animate smoothly to correct destinations

Closes #90