### PR TITLE
fix: pin NPC portraits to bank 2 to prevent SET_BANK crash

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -184,7 +184,30 @@
       "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.worktrees/pragma-255-everywhere/build/junk-runner.gb 2>/dev/null)",
       "Bash(sed:*)",
       "Bash(cp:*)",
-      "Bash(/home/mathdaman/gbdk/bin/romusage build/nuke-raider.gb -a | grep ROM && grep \"b_state_manager_init\" build/nuke-raider.noi)"
+      "Bash(/home/mathdaman/gbdk/bin/romusage build/nuke-raider.gb -a | grep ROM && grep \"b_state_manager_init\" build/nuke-raider.noi)",
+      "Bash(cd:*)",
+      "Bash(/home/mathdaman/gbdk/bin/lcc --version 2>&1 || true; ls /home/mathdaman/gbdk/bin/ 2>&1 | head -30)",
+      "Bash(/home/mathdaman/gbdk/bin/sdcc --version 2>&1)",
+      "Bash(/home/mathdaman/gbdk/bin/sdcc -msm83 --port-target-lib gbz80 -I/home/mathdaman/gbdk/include --debug -c test1.c -o test1.rel)",
+      "Bash(/home/mathdaman/gbdk/bin/bankpack 2>&1 | head -40)",
+      "Bash(sleep:*)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage build/nuke-raider.gb -g 2>&1 | head -25)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage build/nuke-raider.gb -g 2>&1 | head -10)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.worktrees/pragma-255-portraits/build/nuke-raider.gb -a 2>&1)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.worktrees/pragma-255-portraits/build/nuke-raider.gb -B 2>&1)",
+      "Bash(/home/mathdaman/gbdk/bin/bankpack --help 2>&1 || true)",
+      "Bash(/home/mathdaman/gbdk/bin/bankpack 2>&1 | head -40 || true)",
+      "Bash(do)",
+      "Bash(echo \"=== $f ===\")",
+      "Read(//home/mathdaman/code/gmb-nuke-raider/.claude/worktrees/fix-portrait-banking/**)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.claude/worktrees/fix-portrait-banking/build/nuke-raider.gb -sL 2>/dev/null | head -40)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.claude/worktrees/fix-portrait-banking/build/nuke-raider.noi -g 2>/dev/null | head -60)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.claude/worktrees/fix-portrait-banking/build/nuke-raider.gb -a 2>&1)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.claude/worktrees/fix-portrait-banking/build/nuke-raider.gb -B 2>&1)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.claude/worktrees/fix-portrait-banking/build/nuke-raider.gb -s 2>&1 | head -60)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.claude/worktrees/fix-portrait-banking/build/nuke-raider.map -a 2>&1)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /home/mathdaman/code/gmb-nuke-raider/.claude/worktrees/fix-portrait-banking/build/nuke-raider.map -a 2>/dev/null)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage /tmp/nuke-raider-old.gb -sL 2>/dev/null)"
     ]
   }
 }

--- a/.claude/skills/rom-banking/SKILL.md
+++ b/.claude/skills/rom-banking/SKILL.md
@@ -11,15 +11,27 @@ description: Use when the ROM shows a blank screen at low FPS (~2 FPS), when que
 
 **All state code (`state_*.c`, `state_manager.c`) must stay in bank 1.**
 
+## SET_BANK Safety Rule
+
+**`SET_BANK` is only safe from HOME bank (bank 0) code.**
+
+Using `SET_BANK` inside a BANKED function that lives in the switchable window (0x4000–0x7FFF) will switch that window away from the function's own bank. The next instruction reads from the newly-mapped bank → wrong bytes → crash.
+
+**Safe:** HOME bank code (no `#pragma bank`, runs at 0x0000–0x3FFF). Examples: `state_overmap.c`, `state_hub.c`, `main.c`.
+
+**Unsafe:** Any `#pragma bank 255` function that calls `SET_BANK` to switch to a *different* bank. Example: `track_init()` (bank 1) calling `SET_BANK(track_tile_data)` while `track_tile_data` is in bank 2 — unmaps bank 1 mid-execution → crash.
+
+**Corollary:** Data assets accessed via `SET_BANK` from a BANKED function must be in the **same bank** as that function, so the switch is a no-op. If they land in a different bank, move them back or refactor the load into HOME bank code.
+
 ## Bank Budget
 
 | Bank | Used  | Notes |
 |------|-------|-------|
 | ROM_0 | ~56% | Fixed/HOME code, always mapped |
-| ROM_1 | ~100% | All autobanked modules — 14 bytes free, overflows to bank 2 |
-| ROM_2 | ~5%  | Autobank overflow (portraits land here naturally) |
+| ROM_1 | ~100% | All autobanked modules — 14 bytes free |
+| ROM_2 | ~5%  | NPC portraits (pinned to bank 2) |
 
-Current config: MBC1, 4 banks declared (`-Wm-ya4`, `-Wm-yt1`). To add capacity, bump to `-Wm-ya8` — never hardcode bank numbers.
+Current config: MBC5, 16 banks declared (`-Wm-ya16`, `-Wm-yt25`). To add capacity, bump to `-Wm-ya32` — never hardcode bank numbers for game logic or data assets (portraits are the one exception, see below).
 
 ## Diagnosing Bank Overflow
 
@@ -27,45 +39,45 @@ Current config: MBC1, 4 banks declared (`-Wm-ya4`, `-Wm-yt1`). To add capacity, 
 
 ```sh
 # Step 1: Check bank percentages
-/home/mathdaman/gbdk/bin/romusage build/junk-runner.gb -a
+/home/mathdaman/gbdk/bin/romusage build/nuke-raider.gb -a
 
 # Step 2: Find symbols placed in bank 2+ — state_* code here = crash
-grep "024[0-9A-Fa-f]\{3\}" build/junk-runner.map
+grep "024[0-9A-Fa-f]\{3\}" build/nuke-raider.map
 ```
 
 If `_state_ti`, `_state_hu`, `_state_pl`, `_state_ov` appear at `0x024xxx` addresses, bank 1 overflowed and the game will crash at boot.
 
 ## Fix: Bank Overflow
 
-All files use `#pragma bank 255` — bankpack fills bank 1, then overflows to banks 2, 3, etc. automatically. No manual bank assignments needed for data assets.
+All files (except portraits) use `#pragma bank 255` — bankpack fills bank 1, then overflows to banks 2, 3, etc. automatically.
 
-If bank 1 is too full and state code is at risk of overflowing, the fix is to bump `-Wm-ya` to the next power of 2 (e.g., 4→8) in the Makefile. **Never hardcode a bank number** — `#pragma bank 2` is wrong policy.
+If bank 1 is too full and state code is at risk of overflowing, the fix is to bump `-Wm-ya` to the next power of 2 (e.g., 16→32) in the Makefile. **Never hardcode a bank number for game logic or generated tile/map data.**
 
-`BANKREF` / `BANK()` / `SET_BANK()` resolve correctly at link time regardless of which bank a file lands in — no changes needed in callers.
+`BANKREF` / `BANK()` / `SET_BANK()` resolve correctly at link time regardless of which bank a file lands in — no changes needed in callers, **provided the SET_BANK safety rule above is respected**。
 
 ## Asset Banking Rules
 
 | Asset type | Pragma | Reason |
 |------------|--------|--------|
-| `npc_*_portrait.c` | `#pragma bank 255` | Autobanked — bankpack places in bank 2+ naturally |
-| `*_tiles.c` (generated) | `#pragma bank 255` | Autobanked — bankpack places in bank 2+ naturally |
-| `*_map.c` (generated) | `#pragma bank 255` | Autobanked — bankpack places in bank 2+ naturally |
+| `npc_*_portrait.c` | `#pragma bank 2` (hardcoded via `--bank 2`) | **Must not autobank**: portraits compete with game logic for bank 1; if they win, `track_tile_data`/`player_tile_data` move to bank 2, and `SET_BANK` inside BANKED functions crashes. See Makefile comment. |
+| `*_tiles.c` (generated) | `#pragma bank 255` | Autobanked — bankpack places in bank 1 or overflow |
+| `*_map.c` (generated) | `#pragma bank 255` | Autobanked |
 | State modules (`state_*.c`) | `#pragma bank 255` | Must stay in bank 1 with state_manager |
-| `music.c` | no `#pragma bank` (bank 0) | `SET_BANK` cannot be called from banked code — intentionally bank 0 |
+| `music.c` | no `#pragma bank` (bank 0) | VBL ISR calls music_tick — must be in HOME bank |
 
 ## Checklist: After Adding Any Large Asset
 
 1. Build: `GBDK_HOME=/home/mathdaman/gbdk make`
-2. Check bank 1: `romusage build/junk-runner.gb -a` → if bank 1 ≥ 95%, act now
-3. Check for state code overflow: `grep "024[0-9A-Fa-f]\{3\}" build/junk-runner.map`
-4. If state code appears in bank 2+: fix is to bump `-Wm-ya8` in the Makefile so data overflows to bank 3+ instead of pushing state code out of bank 1
+2. Check bank 1: `romusage build/nuke-raider.gb -a` → if bank 1 ≥ 95%, act now
+3. Check for state code overflow: `grep "024[0-9A-Fa-f]\{3\}" build/nuke-raider.map`
+4. Check that `track_tile_data` and `player_tile_data` are still in bank 1 (verify in `.noi` file)
+5. If state code appears in bank 2+: fix is to bump `-Wm-ya32` in the Makefile
 
 ## Autobanker Behavior
 
 - `#pragma bank 255` → bankpack assigns automatically, fills bank 1 first, then spills to bank 2, 3, etc.
-- All files (state code, data assets, portraits, tiles, maps) use `#pragma bank 255`
 - Bankpack fills banks sequentially — state code lands in bank 1, overflow data lands in bank 2+
-- With 4 banks declared (`-Wm-ya4`), bank 2 is available for overflow; bump to `-Wm-ya8` if needed — never hardcode bank numbers
+- With 16 banks declared (`-Wm-ya16`), banks 2–15 are available for overflow
 
 ## Why BANKED Function Pointers Aren't the Fix
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,14 @@ src/player_sprite.c: assets/sprites/player_car.png tools/png_to_tiles.py
 
 $(TARGET): src/player_sprite.c
 
+# NPC portraits are pinned to --bank 2, NOT --bank 255 (autobank).
+# Rationale: bankpack fills bank 1 first; portraits would land in bank 1 and
+# push track_tile_data / player_tile_data to bank 2.  track_init() and
+# player_init() are BANKED functions in bank 1 that call SET_BANK() to reach
+# those assets — SET_BANK inside a banked function in the switchable window
+# (0x4000-0x7FFF) unmaps the executing code and crashes.  Pinning portraits
+# to bank 2 keeps the hot assets (track_tile_data, player_tile_data) in bank 1
+# alongside the code that accesses them, making SET_BANK a no-op there.
 src/npc_mechanic_portrait.c: assets/sprites/npc_mechanic.png tools/png_to_tiles.py
 	python3 tools/png_to_tiles.py --bank 2 assets/sprites/npc_mechanic.png src/npc_mechanic_portrait.c npc_mechanic_portrait
 


### PR DESCRIPTION
## Summary

- NPC portrait C files now use `--bank 2` (hardcoded) instead of `--bank 255` (autobank)
- When portraits autobanked, they competed for bank 1 and pushed `track_tile_data`/`player_tile_data` to bank 2
- `track_init()` and `player_init()` are BANKED functions in bank 1 that call `SET_BANK()` — calling `SET_BANK` from within the switchable ROM window (0x4000–0x7FFF) unmaps the executing code mid-function → crash
- Pinning portraits to bank 2 guarantees the hot tile assets stay in bank 1 alongside the code that loads them, making `SET_BANK` a no-op
- Updated rom-banking skill with the SET_BANK safety rule, corrected MBC5/16-bank config, and new checklist item to verify `track_tile_data`/`player_tile_data` placement

## Test plan

- [x] ROM builds clean: `GBDK_HOME=/home/mathdaman/gbdk make`
- [x] Bank 1 not overflowed: `romusage build/nuke-raider.gb -a` — bank 1 ~100% with 14 bytes free
- [x] No state code at `0x024xxx`: `grep "024[0-9A-Fa-f]\{3\}" build/nuke-raider.map` — clean
- [x] Smoketest passed in Emulicious: title → overmap → track all functional

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)