### PR TITLE
feat: add resolved/unresolved/deferred summary to brainstorming and writing-plans skills

### DIFF
--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -28,9 +28,14 @@ You MUST create a task for each of these items and complete them in order:
 3. **Propose 2-3 approaches** — with trade-offs and your recommendation
 4. **Present design** — in sections scaled to their complexity, get user approval after each section
    - **Design-It-Twice** (required for any new `src/*.c` module): sketch two alternative module interfaces / APIs, compare them explicitly, then choose the better one
-5. **Create GitHub issue** — use `/prd` skill to create a GitHub issue with the design as a PRD.
+5. **Resolved / Unresolved / Deferred summary** — before calling `/prd`, output a short bullet list per category:
+   - **Resolved:** decisions that are settled
+   - **Unresolved:** open questions that must be answered before implementation begins
+   - **Deferred:** items deliberately set aside (not blocking now)
+   If Unresolved is non-empty, stop and resolve those questions before continuing.
+6. **Create GitHub issue** — use `/prd` skill to create a GitHub issue with the design as a PRD.
    Do NOT save a local design doc file. The GitHub issue IS the design doc.
-6. **Transition to implementation** — invoke the `writing-plans` skill (`Skill` tool, `skill: "writing-plans"`) to create the implementation plan
+7. **Transition to implementation** — invoke the `writing-plans` skill (`Skill` tool, `skill: "writing-plans"`) to create the implementation plan
 
 ## GB Constraint Checklist
 
@@ -63,7 +68,12 @@ digraph brainstorming {
     "Propose 2-3 approaches" -> "Present design sections + Design-It-Twice";
     "Present design sections + Design-It-Twice" -> "User approves design?";
     "User approves design?" -> "Present design sections + Design-It-Twice" [label="no, revise"];
-    "User approves design?" -> "Create GitHub issue with /prd" [label="yes"];
+    "User approves design?" -> "Resolved/Unresolved/Deferred summary" [label="yes"];
+    "Resolved/Unresolved/Deferred summary" [shape=box];
+    "Unresolved items?" [shape=diamond];
+    "Resolved/Unresolved/Deferred summary" -> "Unresolved items?";
+    "Unresolved items?" -> "Ask clarifying questions" [label="yes, resolve first"];
+    "Unresolved items?" -> "Create GitHub issue with /prd" [label="no"];
     "Create GitHub issue with /prd" -> "Invoke writing-plans skill";
 }
 ```

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -58,6 +58,10 @@ Non-C tasks (markdown, Python, JSON, assets): write → verify → commit. No ba
 
 **Tech Stack:** [Key technologies/libraries]
 
+## Open questions (must resolve before starting)
+
+- [Question 1 — or delete this line if none]
+
 ---
 ```
 


### PR DESCRIPTION
## Summary

- `brainstorming` skill: adds a new step 5 — **Resolved / Unresolved / Deferred summary** — between design approval and the `/prd` call; process flow diagram updated; if Unresolved is non-empty, the skill stops and forces resolution before continuing
- `writing-plans` skill: plan document header now includes an **Open questions (must resolve before starting)** block so any blockers are visible at the top of every plan in a future session

## Test plan

- [ ] Run through a brainstorming session and verify the summary step appears with three categories before `/prd` is called
- [ ] Verify a plan produced by `writing-plans` has the Open questions block at the top (empty when none)
- [ ] Confirm both skills updated in the same PR (AC3)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)