### PR TITLE
feat: add smoketestable batches, refactor checkpoint, gb-c-optimizer, SoA hints to writing-plans skill

### DIFF
--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -30,7 +30,9 @@ Every task that touches `src/*.c` or `src/*.h` MUST follow this exact sequence �
 | 5 | Run tests (`make test` → PASS) |
 | 6 | Build ROM (`GBDK_HOME=/home/mathdaman/gbdk make` → PASS) |
 | 7 | Invoke `bank-post-build` skill (HARD GATE) |
-| 8 | Commit |
+| 8 | Refactor checkpoint ("breaks when N > 1?") |
+| 9 | Invoke `gb-c-optimizer` agent (HARD GATE) |
+| 10 | Commit |
 
 Non-C tasks (markdown, Python, JSON, assets): write → verify → commit. No bank gates.
 
@@ -42,6 +44,43 @@ Non-C tasks (markdown, Python, JSON, assets): write → verify → commit. No ba
 - "Implement the minimal code to make the test pass" - step
 - "Run the tests and make sure they pass" - step
 - "Commit" - step
+
+## Smoketestable Batches
+
+**Tasks MUST be grouped into batches of 2-4.** Each batch ends with a **Smoketest Checkpoint** — a point where the ROM runs in Emulicious and the user confirms it looks correct.
+
+A good batch boundary = any point where the game should visually work end-to-end (even partially). If a batch cannot be independently smoke-tested, the plan must explain why.
+
+Use this template for every checkpoint:
+
+````markdown
+### Smoketest Checkpoint N — [what to verify visually]
+
+**Step 1: Fetch and merge latest master (from worktree directory)**
+```bash
+git fetch origin && git merge origin/master
+```
+
+**Step 2: Clean build**
+```bash
+make clean && GBDK_HOME=/home/mathdaman/gbdk make
+```
+Expected: ROM at `build/nuke-raider.gb`, zero errors.
+
+**Step 3: Memory check**
+```bash
+make memory-check
+```
+Expected: All budgets PASS. Fix any FAIL or ERROR before continuing.
+
+**Step 4: Launch ROM (run from worktree directory)**
+```bash
+java -jar /home/mathdaman/.local/share/emulicious/Emulicious.jar build/nuke-raider.gb
+```
+
+**Step 5: Confirm with user**
+Tell the user what to verify visually. Wait for confirmation before proceeding to the next batch.
+````
 
 ## Plan Document Header
 
@@ -75,6 +114,9 @@ Use this template for any task that creates or modifies `src/*.c` or `src/*.h`:
 **Files:**
 - Create: `src/foo.c`, `src/foo.h`
 - Test: `tests/test_foo.c`
+
+> **Entity system?** Use SoA (Structure-of-Arrays). Capacity constants in `src/config.h`.
+> Never AoS — SDCC cannot eliminate stride multiplication on SM83.
 
 **Step 1: Write the failing test**
 
@@ -123,7 +165,18 @@ Expected: ROM produced at `build/nuke-raider.gb`, zero errors.
 
 Invoke the `bank-post-build` skill. Verify bank placements and ROM budgets are within limits.
 
-**Step 9: Commit**
+**Step 9: Refactor checkpoint**
+
+Ask: "Does this implementation generalize, or did I hard-code something that breaks when N > 1?"
+- If generalized: proceed.
+- If hard-coded and not fixing now: open a follow-up GitHub issue immediately before closing this task.
+
+**Step 10: HARD GATE — gb-c-optimizer**
+
+Invoke the `gb-c-optimizer` agent on the new/modified C files.
+Fix any AoS, performance, or ROM size issues before committing.
+
+**Step 11: Commit**
 
 ```bash
 git add src/foo.c src/foo.h tests/test_foo.c bank-manifest.json
@@ -163,7 +216,9 @@ git commit -m "feat: add/update X"
 - Exact commands with expected output
 - Reference skills by name (e.g., `bank-pre-write` skill, `gbdk-expert` agent)
 - DRY, YAGNI, TDD, frequent commits
-- C files ALWAYS get the 8-step template with all three HARD GATE steps
+- C files ALWAYS get the 11-step template with all HARD GATE steps
+- Group tasks into batches of 2-4; each batch MUST end with a Smoketest Checkpoint
+- Mark tasks that create independent files as parallelizable — implementer can dispatch them as concurrent subagents
 
 ## Execution Handoff
 


### PR DESCRIPTION
## Summary

- Tasks must now be grouped into batches of 2-4, each ending with a **Smoketest Checkpoint** (Emulicious + user confirms)
- C-file task template extended to 11 steps: adds refactor checkpoint ("breaks when N > 1?") and `gb-c-optimizer` hard gate before commit
- SoA entity system reminder added to C-file task template header
- Parallel task hint added to Remember section
- Hard Gate Sequence table updated to reflect all 10 steps

## Test plan

- [ ] Invoke the `writing-plans` skill on a new feature and verify the plan includes Smoketest Checkpoints every 2-4 tasks
- [ ] Verify C-file tasks include steps 9 (refactor checkpoint) and 10 (gb-c-optimizer) before commit
- [ ] Verify the SoA note appears in C-file task templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)