### PR TITLE
feat: damage module — HP pool, apply, heal, invincibility (Task 1/5)

### DIFF
--- a/bank-manifest.json
+++ b/bank-manifest.json
@@ -3,6 +3,7 @@
   "src/dialog.c":                {"bank": 255, "reason": "autobank"},
   "src/dialog_arrow_sprite.c":   {"bank": 255, "reason": "autobank"},
   "src/dialog_border_tiles.c":   {"bank": 255, "reason": "autobank — no longer needs pinning after state_manager moved to bank 0"},
+  "src/damage.c":                {"bank": 255, "reason": "autobank"},
   "src/dialog_data.c":           {"bank": 255, "reason": "autobank"},
   "src/hub_data.c":              {"bank": 0,   "reason": "bank-0 data, always mapped — no #pragma bank"},
   "src/loader.c":                {"bank": 0,   "reason": "NONBANKED VRAM loaders — only bank-0 code may call SWITCH_ROM"},

--- a/src/config.h
+++ b/src/config.h
@@ -27,6 +27,11 @@
 #define PLAYER_HP        100 /* Damage system: starting HP (equals PLAYER_HP_MAX — full health) */
 #define PLAYER_FUEL      20  /* Fuel depletion system (not yet implemented) */
 
+/* Damage system */
+#define PLAYER_MAX_HP              8u   /* max HP pool; 0 = dead */
+#define DAMAGE_REPAIR_AMOUNT       2u   /* HP restored by TILE_REPAIR */
+#define DAMAGE_INVINCIBILITY_FRAMES 30u /* frames of i-frames after a hit */
+
 #define MAP_TILES_W  20u
 #define MAP_TILES_H  100u
 

--- a/src/damage.c
+++ b/src/damage.c
@@ -1,0 +1,45 @@
+#pragma bank 255
+#include "damage.h"
+#include "config.h"
+
+static uint8_t hp;
+static uint8_t invincibility_cooldown;
+
+void damage_init(void) BANKED {
+    hp                     = PLAYER_MAX_HP;
+    invincibility_cooldown = 0u;
+}
+
+void damage_tick(void) BANKED {
+    if (invincibility_cooldown > 0u) {
+        invincibility_cooldown = (uint8_t)(invincibility_cooldown - 1u);
+    }
+}
+
+void damage_apply(uint8_t amount) BANKED {
+    if (invincibility_cooldown > 0u) return;
+    if (hp == 0u)                    return;
+    if (amount >= hp) {
+        hp = 0u;
+    } else {
+        hp = (uint8_t)(hp - amount);
+    }
+    invincibility_cooldown = DAMAGE_INVINCIBILITY_FRAMES;
+}
+
+void damage_heal(uint8_t amount) BANKED {
+    uint8_t new_hp = (uint8_t)(hp + amount);
+    if (new_hp > PLAYER_MAX_HP || new_hp < hp) {  /* overflow guard */
+        hp = PLAYER_MAX_HP;
+    } else {
+        hp = new_hp;
+    }
+}
+
+uint8_t damage_is_dead(void) BANKED {
+    return (hp == 0u) ? 1u : 0u;
+}
+
+uint8_t damage_get_hp(void) BANKED {
+    return hp;
+}

--- a/src/damage.h
+++ b/src/damage.h
@@ -1,0 +1,28 @@
+#ifndef DAMAGE_H
+#define DAMAGE_H
+
+#include <gb/gb.h>
+#include <stdint.h>
+
+/* Initialise HP to PLAYER_MAX_HP and clear invincibility cooldown.
+ * Call from state_playing enter(), before DISPLAY_ON. */
+void    damage_init(void) BANKED;
+
+/* Decrement invincibility cooldown by 1 (no-op if already 0).
+ * Call once per frame in state_playing update(). */
+void    damage_tick(void) BANKED;
+
+/* Apply `amount` damage. No-op if invincible or already dead.
+ * Sets invincibility cooldown to DAMAGE_INVINCIBILITY_FRAMES on hit. */
+void    damage_apply(uint8_t amount) BANKED;
+
+/* Restore `amount` HP, capped at PLAYER_MAX_HP. */
+void    damage_heal(uint8_t amount) BANKED;
+
+/* Returns 1 if hp == 0, else 0. */
+uint8_t damage_is_dead(void) BANKED;
+
+/* Returns current HP (0–PLAYER_MAX_HP). */
+uint8_t damage_get_hp(void) BANKED;
+
+#endif /* DAMAGE_H */

--- a/src/track.h
+++ b/src/track.h
@@ -12,6 +12,7 @@ typedef uint8_t TileType;
 #define TILE_SAND   2u
 #define TILE_OIL    3u
 #define TILE_BOOST  4u
+#define TILE_REPAIR 5u
 
 TileType track_tile_type_from_index(uint8_t tile_idx) BANKED;
 TileType track_tile_type(int16_t world_x, int16_t world_y) BANKED;

--- a/tests/test_damage.c
+++ b/tests/test_damage.c
@@ -1,0 +1,204 @@
+/* tests/test_damage.c — unit tests for the damage module */
+#include "unity.h"
+#include <gb/gb.h>
+#include "../src/config.h"
+#include "../src/damage.h"
+
+void setUp(void)    { damage_init(); }
+void tearDown(void) {}
+
+/* --- init --- */
+
+void test_init_sets_full_hp(void) {
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP, damage_get_hp());
+}
+
+void test_init_not_dead(void) {
+    TEST_ASSERT_EQUAL_UINT8(0u, damage_is_dead());
+}
+
+void test_init_not_invincible(void) {
+    /* Apply immediately after init must deal damage (not blocked by i-frames) */
+    damage_apply(1u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 1u, damage_get_hp());
+}
+
+/* --- damage_apply --- */
+
+void test_apply_reduces_hp_by_one(void) {
+    damage_apply(1u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 1u, damage_get_hp());
+}
+
+void test_apply_reduces_hp_by_amount(void) {
+    damage_apply(3u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 3u, damage_get_hp());
+}
+
+void test_apply_clamps_to_zero_no_underflow(void) {
+    damage_apply(100u);
+    TEST_ASSERT_EQUAL_UINT8(0u, damage_get_hp());
+}
+
+void test_apply_exact_to_zero(void) {
+    damage_apply(PLAYER_MAX_HP);
+    TEST_ASSERT_EQUAL_UINT8(0u, damage_get_hp());
+}
+
+void test_apply_is_dead_at_zero(void) {
+    damage_apply(PLAYER_MAX_HP);
+    TEST_ASSERT_EQUAL_UINT8(1u, damage_is_dead());
+}
+
+void test_apply_not_dead_above_zero(void) {
+    damage_apply(1u);
+    TEST_ASSERT_EQUAL_UINT8(0u, damage_is_dead());
+}
+
+void test_apply_sets_invincibility(void) {
+    damage_apply(1u);
+    /* second apply must be blocked (i-frames active) */
+    damage_apply(1u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 1u, damage_get_hp());
+}
+
+void test_apply_skips_second_hit_within_iframes(void) {
+    uint8_t i;
+    damage_apply(1u);
+    /* tick 29 times (one short of cooldown expiry) */
+    for (i = 0u; i < DAMAGE_INVINCIBILITY_FRAMES - 1u; i++) damage_tick();
+    damage_apply(1u);  /* still invincible */
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 1u, damage_get_hp());
+}
+
+void test_apply_hits_after_iframes_expire(void) {
+    uint8_t i;
+    damage_apply(1u);
+    for (i = 0u; i < DAMAGE_INVINCIBILITY_FRAMES; i++) damage_tick();
+    damage_apply(1u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 2u, damage_get_hp());
+}
+
+void test_apply_zero_amount_no_effect(void) {
+    damage_apply(0u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP, damage_get_hp());
+}
+
+void test_dead_player_not_damaged_further(void) {
+    damage_apply(PLAYER_MAX_HP);        /* hp → 0 */
+    uint8_t i;
+    for (i = 0u; i < DAMAGE_INVINCIBILITY_FRAMES; i++) damage_tick();
+    damage_apply(1u);                   /* should be skipped — already dead */
+    TEST_ASSERT_EQUAL_UINT8(0u, damage_get_hp());
+}
+
+/* --- damage_tick --- */
+
+void test_tick_no_effect_when_not_invincible(void) {
+    /* No crash / underflow when ticking with zero cooldown */
+    damage_tick();
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP, damage_get_hp());
+}
+
+void test_tick_30_times_expires_iframes(void) {
+    uint8_t i;
+    damage_apply(1u);
+    for (i = 0u; i < DAMAGE_INVINCIBILITY_FRAMES; i++) damage_tick();
+    /* now should be able to take damage again */
+    damage_apply(1u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 2u, damage_get_hp());
+}
+
+void test_tick_exact_boundary_at_29_still_invincible(void) {
+    uint8_t i;
+    damage_apply(1u);
+    for (i = 0u; i < DAMAGE_INVINCIBILITY_FRAMES - 1u; i++) damage_tick();
+    damage_apply(1u);  /* tick 29: still invincible */
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 1u, damage_get_hp());
+}
+
+/* --- damage_heal --- */
+
+void test_heal_adds_hp(void) {
+    damage_apply(3u);
+    damage_heal(1u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 2u, damage_get_hp());
+}
+
+void test_heal_caps_at_max(void) {
+    damage_apply(1u);
+    damage_heal(100u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP, damage_get_hp());
+}
+
+void test_heal_exact_to_max(void) {
+    damage_apply(2u);
+    damage_heal(DAMAGE_REPAIR_AMOUNT);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP, damage_get_hp());
+}
+
+void test_heal_from_zero_restores_hp(void) {
+    damage_apply(PLAYER_MAX_HP);        /* hp → 0 */
+    damage_heal(DAMAGE_REPAIR_AMOUNT);
+    TEST_ASSERT_EQUAL_UINT8(DAMAGE_REPAIR_AMOUNT, damage_get_hp());
+}
+
+void test_heal_zero_amount_no_effect(void) {
+    damage_apply(2u);
+    damage_heal(0u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 2u, damage_get_hp());
+}
+
+void test_heal_from_zero_not_dead_after_heal(void) {
+    damage_apply(PLAYER_MAX_HP);
+    damage_heal(1u);
+    TEST_ASSERT_EQUAL_UINT8(0u, damage_is_dead());
+}
+
+/* --- damage_get_hp --- */
+
+void test_get_hp_after_init(void) {
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP, damage_get_hp());
+}
+
+void test_get_hp_decrements_with_apply(void) {
+    damage_apply(1u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 1u, damage_get_hp());
+}
+
+void test_get_hp_increments_with_heal(void) {
+    damage_apply(2u);
+    damage_heal(1u);
+    TEST_ASSERT_EQUAL_UINT8(PLAYER_MAX_HP - 1u, damage_get_hp());
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_init_sets_full_hp);
+    RUN_TEST(test_init_not_dead);
+    RUN_TEST(test_init_not_invincible);
+    RUN_TEST(test_apply_reduces_hp_by_one);
+    RUN_TEST(test_apply_reduces_hp_by_amount);
+    RUN_TEST(test_apply_clamps_to_zero_no_underflow);
+    RUN_TEST(test_apply_exact_to_zero);
+    RUN_TEST(test_apply_is_dead_at_zero);
+    RUN_TEST(test_apply_not_dead_above_zero);
+    RUN_TEST(test_apply_sets_invincibility);
+    RUN_TEST(test_apply_skips_second_hit_within_iframes);
+    RUN_TEST(test_apply_hits_after_iframes_expire);
+    RUN_TEST(test_apply_zero_amount_no_effect);
+    RUN_TEST(test_dead_player_not_damaged_further);
+    RUN_TEST(test_tick_no_effect_when_not_invincible);
+    RUN_TEST(test_tick_30_times_expires_iframes);
+    RUN_TEST(test_tick_exact_boundary_at_29_still_invincible);
+    RUN_TEST(test_heal_adds_hp);
+    RUN_TEST(test_heal_caps_at_max);
+    RUN_TEST(test_heal_exact_to_max);
+    RUN_TEST(test_heal_from_zero_restores_hp);
+    RUN_TEST(test_heal_zero_amount_no_effect);
+    RUN_TEST(test_heal_from_zero_not_dead_after_heal);
+    RUN_TEST(test_get_hp_after_init);
+    RUN_TEST(test_get_hp_decrements_with_apply);
+    RUN_TEST(test_get_hp_increments_with_heal);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- Adds standalone `damage` module: `damage_init`, `damage_apply`, `damage_heal`, `damage_tick`, `damage_is_dead`, `damage_get_hp`
- Adds 3 constants to `config.h`: `PLAYER_MAX_HP=8`, `DAMAGE_REPAIR_AMOUNT=2`, `DAMAGE_INVINCIBILITY_FRAMES=30`
- Adds `TILE_REPAIR=5` to `track.h`
- 26 unit tests, all passing; module compiled in but not yet wired to game logic
- Smoketest: title screen and race entry work normally — no regression

## Test plan
- [x] `make test` — 26 new test_damage tests pass, 0 failures
- [x] `make bank-post-build` — all ROM banks PASS
- [x] `make memory-check` — WRAM 7%, VRAM 5%, OAM 47%
- [x] Emulicious smoketest — game launches, race plays normally

Closes part of #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)