### PR TITLE
feat: player flicker at low HP + fix first-frame scroll on race entry (Task 3/5)

### DIFF
--- a/src/player.c
+++ b/src/player.c
@@ -16,6 +16,7 @@ static int8_t  vx;
 static int8_t  vy;
 static uint8_t player_sprite_slot     = 0;
 static uint8_t player_sprite_slot_bot = 0;
+static uint8_t player_flicker_tick;
 
 /* Returns 1 if all 4 corners of a player at world (wx, wy) are on track. */
 static uint8_t corners_passable(int16_t wx, int16_t wy) {
@@ -37,6 +38,7 @@ void player_init(void) BANKED {
     load_track_start_pos(&px, &py);
     vx = 0;
     vy = 0;
+    player_flicker_tick = 0u;
     SHOW_SPRITES;
 }
 
@@ -71,12 +73,17 @@ void player_update(void) BANKED {
 }
 
 void player_render(void) BANKED {
-    /* cam_x is always 0; cam_y is uint16_t but py >= cam_y is enforced so offset fits uint8_t */
     uint8_t hw_x = (uint8_t)(px + 8);
     uint8_t hw_y = (uint8_t)((int16_t)py - (int16_t)cam_y + 16);
-    move_sprite(player_sprite_slot,     hw_x, hw_y);
-    move_sprite(player_sprite_slot_bot, hw_x, (uint8_t)(hw_y + 8u));
-
+    player_flicker_tick++;
+    if (damage_get_hp() <= 2u && (player_flicker_tick & 8u)) {
+        /* Hide: move both halves off-screen (y=0 is above OAM visible area) */
+        move_sprite(player_sprite_slot,     0u, 0u);
+        move_sprite(player_sprite_slot_bot, 0u, 0u);
+    } else {
+        move_sprite(player_sprite_slot,     hw_x, hw_y);
+        move_sprite(player_sprite_slot_bot, hw_x, (uint8_t)(hw_y + 8u));
+    }
 }
 
 void player_set_pos(int16_t x, int16_t y) BANKED {

--- a/src/state_overmap.c
+++ b/src/state_overmap.c
@@ -165,6 +165,7 @@ static void enter(void) {
     { SET_BANK(overmap_map);
       set_bkg_tiles(0u, 0u, OVERMAP_W, OVERMAP_H, overmap_map);
       RESTORE_BANK(); }
+    move_bkg(0u, 0u);   /* reset SCY: overmap has no vertical scroll */
     DISPLAY_ON;
 
     SHOW_BKG;

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -1,6 +1,5 @@
 #pragma bank 255
 #include <gb/gb.h>
-#include <gbdk/emu_debug.h>
 #include "banking.h"
 #include "input.h"
 #include "state_manager.h"
@@ -12,23 +11,25 @@ BANKREF_EXTERN(state_playing)
 #include "track.h"
 #include "camera.h"
 #include "hud.h"
+#include "loader.h"
 #include "damage.h"
 #include "state_game_over.h"
 
 static void enter(void) {
-    EMU_printf("PLAYING enter\n");
-    player_set_pos(track_start_x, track_start_y);
-    EMU_printf("PLAYING pos set\n");
+    {
+        int16_t sx, sy;
+        load_track_start_pos(&sx, &sy);
+        player_set_pos(sx, sy);
+    }
     player_reset_vel();
     damage_init();          /* reset HP pool for new race */
     DISPLAY_OFF;
     track_init();
-    EMU_printf("PLAYING track_init done\n");
     camera_init(player_get_x(), player_get_y());
-    EMU_printf("PLAYING camera_init done\n");
     hud_init();
+    camera_apply_scroll();  /* pre-set SCY so first visible frame is correct */
+    player_render();        /* pre-set OAM so sprites start in race position  */
     DISPLAY_ON;
-    EMU_printf("PLAYING enter done\n");
 }
 
 static void update(void) {

--- a/tests/test_player.c
+++ b/tests/test_player.c
@@ -3,6 +3,7 @@
 #include "../src/input.h"
 #include "player.h"
 #include "camera.h"
+#include "../src/damage.h"
 
 /* input/prev_input globals defined in tests/mocks/input_globals.c */
 
@@ -12,6 +13,7 @@ void setUp(void) {
     mock_vram_clear();
     mock_move_sprite_reset();
     camera_init(88, 720);  /* cam_y = 648 */
+    damage_init();
     player_init();
 }
 void tearDown(void) {}
@@ -173,6 +175,45 @@ void test_brake_while_moving_laterally_does_not_reverse_x(void) {
     TEST_ASSERT_GREATER_OR_EQUAL_INT8(0, player_get_vx());
 }
 
+/* --- flicker: HP > 2 = no hide --- */
+void test_render_at_full_hp_calls_move_sprite_normally(void) {
+    /* setUp calls damage_init → full HP */
+    mock_move_sprite_reset();
+    player_render();
+    /* Both halves must be placed on-screen (y > 0) */
+    TEST_ASSERT_GREATER_THAN_UINT8(0u, mock_sprite_y[0]);
+    TEST_ASSERT_GREATER_THAN_UINT8(0u, mock_sprite_y[1]);
+}
+
+/* --- flicker: HP <= 2, frame counter bit 3 set = hide --- */
+void test_render_at_low_hp_hides_on_flicker_frame(void) {
+    uint8_t i;
+    /* Force hp to 1 */
+    damage_init();
+    damage_apply((uint8_t)(PLAYER_MAX_HP - 1u));  /* hp = 1 */
+    /* Burn 30 frames of i-frames */
+    for (i = 0u; i < DAMAGE_INVINCIBILITY_FRAMES; i++) damage_tick();
+    /* Call render 8 times (frame counter = 0..7, bit3 = 0: visible)
+     * then 1 more (frame counter = 8, bit3 = 1: hidden) */
+    for (i = 0u; i < 8u; i++) player_render();
+    mock_move_sprite_reset();
+    player_render();  /* frame_counter == 8, bit3 set → hide */
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_y[0]);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_y[1]);
+}
+
+/* --- flicker: HP <= 2, frame counter bit 3 clear = visible --- */
+void test_render_at_low_hp_visible_on_non_flicker_frame(void) {
+    uint8_t i;
+    damage_init();
+    damage_apply((uint8_t)(PLAYER_MAX_HP - 1u));
+    for (i = 0u; i < DAMAGE_INVINCIBILITY_FRAMES; i++) damage_tick();
+    /* frame_counter=0 at init, bit3=0: visible */
+    mock_move_sprite_reset();
+    player_render();
+    TEST_ASSERT_GREATER_THAN_UINT8(0u, mock_sprite_y[0]);
+}
+
 /* AC3: J_B while moving must NOT reverse the car. */
 void test_brake_while_moving_does_not_reverse(void) {
     player_apply_physics(J_RIGHT | J_A, TILE_ROAD);  /* vx = 1 */
@@ -203,5 +244,8 @@ int main(void) {
     RUN_TEST(test_brake_while_stopped_facing_up_reverses_down);
     RUN_TEST(test_brake_while_moving_laterally_does_not_reverse_x);
     RUN_TEST(test_brake_while_moving_does_not_reverse);
+    RUN_TEST(test_render_at_full_hp_calls_move_sprite_normally);
+    RUN_TEST(test_render_at_low_hp_hides_on_flicker_frame);
+    RUN_TEST(test_render_at_low_hp_visible_on_non_flicker_frame);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- **Player flicker at low HP**: when `hp ≤ 2`, the car sprite hides on every frame where `player_flicker_tick & 8` is set (125ms on/off at 60fps), giving the player a visual warning before death
- **Fix: car at wrong position after game over + restart**: `DISPLAY_ON` in `state_playing.enter()` was firing before `SCY` and OAM were updated for the new race. Added `camera_apply_scroll()` + `player_render()` calls while the display is still off, so the first visible frame is always correct
- **Fix: overmap inherits stale scroll from race**: added `move_bkg(0u, 0u)` in `state_overmap.enter()` so the overmap never shows with a leftover `SCY` value from the previous race
- **Tests**: 3 new flicker tests in `test_player.c` (full HP visible, low HP hides on bit-3 frame, low HP visible on non-bit-3 frame)

## Test plan

- [ ] Build succeeds, all 27 tests pass, bank-post-build PASS, memory-check PASS
- [ ] First race: car spawns at start position
- [ ] Drive into walls until HP drops to 1–2: car flickers
- [ ] Die (HP = 0): game over screen appears
- [ ] Restart → race again: car spawns at correct start position (not at previous death location)
- [ ] Complete a race (reach finish line): return to overmap, no visual glitches

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)