### PR TITLE
feat: wire damage HP to HUD display (Task 5/5)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,6 @@
 /* Player vehicle stats — reserved for future systems; values are tunable placeholders */
 #define PLAYER_HANDLING  3   /* Turning/handling system (not yet implemented) */
 #define PLAYER_ARMOR     5   /* Damage system: reduces incoming damage before it applies to HP */
-#define PLAYER_HP        100 /* Damage system: starting HP (equals PLAYER_HP_MAX — full health) */
 #define PLAYER_FUEL      20  /* Fuel depletion system (not yet implemented) */
 
 /* Damage system */
@@ -36,7 +35,6 @@
 #define MAP_TILES_H  100u
 
 #define HUD_SCANLINE 128  /* pixel row where HUD window begins; used for player movement bounds */
-#define PLAYER_HP_MAX 100
 
 /* Terrain physics modifiers */
 #define TERRAIN_SAND_FRICTION_MUL  2u   /* friction steps applied on sand (double) */

--- a/src/hud.c
+++ b/src/hud.c
@@ -68,7 +68,7 @@ void hud_init(void) BANKED {
     static uint8_t row1[20];
     uint8_t i;
 
-    hud_hp         = PLAYER_HP_MAX;
+    hud_hp         = PLAYER_MAX_HP;
     hud_frame_tick = 0u;
     hud_seconds    = 0u;
     hud_dirty      = 0u;
@@ -83,9 +83,9 @@ void hud_init(void) BANKED {
     row0[0]  = HUD_FONT_BASE + HUD_TILE_H;
     row0[1]  = HUD_FONT_BASE + HUD_TILE_P;
     row0[2]  = HUD_FONT_BASE + HUD_TILE_COLON;
-    row0[3]  = HUD_FONT_BASE + (uint8_t)(PLAYER_HP_MAX / 100u);
-    row0[4]  = HUD_FONT_BASE + (uint8_t)((PLAYER_HP_MAX / 10u) % 10u);
-    row0[5]  = HUD_FONT_BASE + (uint8_t)(PLAYER_HP_MAX % 10u);
+    row0[3]  = HUD_FONT_BASE + HUD_TILE_SPACE;   /* hundreds: always blank for 0-8 */
+    row0[4]  = HUD_FONT_BASE + HUD_TILE_SPACE;   /* tens:     always blank for 0-8 */
+    row0[5]  = HUD_FONT_BASE + PLAYER_MAX_HP;     /* units:    initial = 8 */
     row0[15] = HUD_FONT_BASE + 0u;             /* MM tens */
     row0[16] = HUD_FONT_BASE + 0u;             /* MM units */
     row0[17] = HUD_FONT_BASE + HUD_TILE_COLON;
@@ -133,9 +133,9 @@ void hud_render(void) BANKED {
     set_win_tiles(15u, 0u, 5u, 1u, timer);
 
     /* Update HP digit tiles (cols 3-5) */
-    hp_digits[0] = HUD_FONT_BASE + (uint8_t)(hud_hp / 100u);
-    hp_digits[1] = HUD_FONT_BASE + (uint8_t)((hud_hp / 10u) % 10u);
-    hp_digits[2] = HUD_FONT_BASE + (uint8_t)(hud_hp % 10u);
+    hp_digits[0] = HUD_FONT_BASE + HUD_TILE_SPACE;  /* hundreds: always blank */
+    hp_digits[1] = HUD_FONT_BASE + HUD_TILE_SPACE;  /* tens:     always blank */
+    hp_digits[2] = HUD_FONT_BASE + hud_hp;           /* units:    direct digit 0-8 */
     set_win_tiles(3u, 0u, 3u, 1u, hp_digits);
 
     hud_dirty = 0u;

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -40,6 +40,7 @@ static void update(void) {
     camera_apply_scroll();   /* SCY applied AFTER VRAM is ready */
     /* Game logic phase: runs during active display */
     player_update();
+    hud_set_hp(damage_get_hp());    /* sync damage HP to HUD each frame */
     camera_update(player_get_x(), player_get_y());
     hud_update();
     /* Death check */


### PR DESCRIPTION
## Summary
- `hud.c`: HP display switched from 3-digit `PLAYER_HP_MAX=100` to single-digit `PLAYER_MAX_HP=8`; both init and render use space/space/digit layout
- `state_playing.c`: `hud_set_hp(damage_get_hp())` called each frame after `player_update()` so the HUD reflects real damage HP
- `config.h`: removed stale `PLAYER_HP` and `PLAYER_HP_MAX` defines

Closes #50

## Test plan
- [x] All test suites pass (0 failures)
- [x] `make bank-post-build` — PASS
- [x] `make memory-check` — PASS
- [x] Smoketest: HUD shows "HP: 8" at race start; wall hits decrement digit; repair pad increments; HP=0 → game over; overmap car spawns correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)