### PR TITLE
feat: add lessons-learned step to executing-plans skill

### DIFF
--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -94,6 +94,15 @@ After all tasks complete and verified, run the smoketest sequence:
    - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
    - Follow that skill to verify tests, present options, execute choice.
 
+### Step 7: Lessons Learned
+
+After the smoketest passes (before pushing/PR), ask:
+
+> "Any important lessons learned from this implementation? (e.g. surprises, sharp edges, things that should update CLAUDE.md / skills / agents / memory)"
+
+- If **yes** or the user provides lessons: invoke the `/prd` skill to create a GitHub issue capturing the needed documentation updates.
+- If **no** or lessons are trivial: skip the PRD and proceed normally.
+
 ## When to Stop and Ask for Help
 
 **STOP executing immediately when:**

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -220,6 +220,10 @@ git commit -m "feat: add/update X"
 - Group tasks into batches of 2-4; each batch MUST end with a Smoketest Checkpoint
 - Mark tasks that create independent files as parallelizable — implementer can dispatch them as concurrent subagents
 
+## Lessons Learned Gate
+
+**Note for plan authors:** The `executing-plans` skill includes a final "Lessons Learned" step (Step 7) that runs after the smoketest passes. The implementer will ask the user whether any lessons should be captured as documentation updates (CLAUDE.md, memory, skills, or agents). No action is needed in the plan itself — this gate runs automatically at execution time.
+
 ## Execution Handoff
 
 After saving the plan, offer execution choice:


### PR DESCRIPTION
## Summary
- Adds **Step 7: Lessons Learned** to `executing-plans` — after the smoketest passes, Claude asks the user for any lessons that should update CLAUDE.md / skills / agents / memory, then invokes `/prd` if warranted
- Adds a **Lessons Learned Gate** note to `writing-plans` so plan authors know the gate runs at execution time

Closes #159

## Test plan
- [ ] Verify `executing-plans` Step 7 appears after the smoketest sequence and before pushing/PR
- [ ] Verify the prompt lists all four artifact targets (CLAUDE.md, memory, skills, agents)
- [ ] Verify `writing-plans` note correctly describes the gate as automatic / no plan changes needed
- [ ] Verify no PRD is auto-created — gate is conditional on user response

🤖 Generated with [Claude Code](https://claude.com/claude-code)