### PR TITLE
chore: sync master at start of writing-plans and executing-plans

### DIFF
--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -29,14 +29,22 @@ Expected: current directory is under `.claude/worktrees/` and branch is a featur
 
 If not in a worktree: use the `using-git-worktrees` skill or `EnterWorktree` tool before proceeding.
 
-### Step 2: Load and Review Plan
+### Step 2: Sync with master
+
+After confirming you are in a worktree, pull and merge latest master:
+```bash
+git fetch origin && git merge origin/master
+```
+NEVER use `git merge master` alone — the local master ref may be stale. Resolve any conflicts before proceeding.
+
+### Step 3: Load and Review Plan
 
 1. Read plan file
 2. Review critically — identify any questions or concerns about the plan
 3. If concerns: raise them with your human partner before starting
 4. If no concerns: create TodoWrite tasks and proceed
 
-### Step 3: Execute Batch
+### Step 4: Execute Batch
 
 **Default: first 3 tasks (or all remaining if fewer than 3)**
 
@@ -52,25 +60,25 @@ For each task:
 5. Run verifications as specified
 6. Mark as completed
 
-### Step 4: Report
+### Step 5: Report
 
 When batch complete:
 - Show what was implemented
 - Show verification output
 - Say: "Ready for feedback."
 
-### Step 5: Continue
+### Step 6: Continue
 
 Based on feedback:
 - Apply changes if needed
 - Execute next batch
 - Repeat until complete
 
-### Step 6: Complete Development
+### Step 7: Complete Development
 
 After all tasks complete and verified, run the smoketest sequence:
 
-1. Fetch and merge latest master (from the worktree directory):
+1. Fetch and merge latest master again (from the worktree directory) to ensure you're up to date before pushing:
    ```bash
    git fetch origin && git merge origin/master
    ```
@@ -94,7 +102,7 @@ After all tasks complete and verified, run the smoketest sequence:
    - **REQUIRED SUB-SKILL:** Use superpowers:finishing-a-development-branch
    - Follow that skill to verify tests, present options, execute choice.
 
-### Step 7: Lessons Learned
+### Step 8: Lessons Learned
 
 After the smoketest passes (before pushing/PR), ask:
 
@@ -116,7 +124,7 @@ After the smoketest passes (before pushing/PR), ask:
 
 ## When to Revisit Earlier Steps
 
-**Return to Review (Step 2) when:**
+**Return to Review (Step 3) when:**
 - Partner updates the plan based on your feedback
 - Fundamental approach needs rethinking
 

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -13,6 +13,12 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 **Announce at start:** "I'm using the writing-plans skill to create the implementation plan."
 
+**First action before anything else:** Pull and merge latest master into the current worktree branch:
+```bash
+git fetch origin && git merge origin/master
+```
+Resolve any conflicts before proceeding.
+
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill).
 
 **Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`


### PR DESCRIPTION
## Summary
- Adds `git fetch origin && git merge origin/master` as the **first action** in `writing-plans` (before exploring the codebase)
- Adds a new **Step 2: Sync with master** in `executing-plans` (after worktree check, before loading the plan), renumbers subsequent steps

## Why
Ensures plans are written and executed against up-to-date master, preventing stale-branch surprises mid-implementation.

## Test plan
- [ ] Run `/writing-plans` — verify the sync step appears immediately after the announce line
- [ ] Run `/executing-plans` — verify Step 2 is the sync step and all subsequent steps are numbered correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)