### PR TITLE
docs: auto-invoke writing-plans when GitHub issue URL is pasted

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,8 @@ These live in `.claude/skills/` and take precedence over the global superpowers 
 This project uses [Superpowers](https://github.com/obra/superpowers) (installed globally in `~/.claude/`).
 
 **Outer loop:** brainstorming → PRD (`/prd`) → [separate session] writing-plans → subagent-driven-development
+
+**GitHub issue links:** When the user pastes a GitHub issue URL (e.g. `https://github.com/.../issues/N`), immediately invoke the `writing-plans` skill — do not ask for confirmation.
 **TDD red/green command:** `make test` (gcc + Unity, no hardware needed — use `/test` skill)
 **Bank manifest maintenance:** Every new `src/*.c` file must have an entry in `bank-manifest.json` before it is written. `bank-pre-write` skill and `bank_check.py` (Makefile dependency) both enforce this. Every banking-related PR must update ALL artifacts: `bank-manifest.json`, both bank skills, `bank_check.py`, `gbdk-expert`, `gb-memory-validator`, and this file.
 **Build verification:** `GBDK_HOME=/home/mathdaman/gbdk make` (use `/build` skill)


### PR DESCRIPTION
## Summary
- Adds a CLAUDE.md instruction to automatically invoke the `writing-plans` skill whenever a GitHub issue URL is pasted into the conversation
- No code changes — workflow documentation only

## Test Plan
- [ ] Paste a GitHub issue URL in a new session and confirm `writing-plans` is invoked without prompting