### PR TITLE
chore: gated pipeline — self-review checkpoints at brainstorming, plan, and pre-PR transitions

### DIFF
--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -34,9 +34,16 @@ You MUST create a task for each of these items and complete them in order:
    - **Unresolved:** open questions that must be answered before implementation begins
    - **Deferred:** items deliberately set aside (not blocking now)
    If Unresolved is non-empty, stop and resolve those questions before continuing.
-7. **Create GitHub issue** — use `/prd` skill to create a GitHub issue with the design as a PRD.
+7. **PRD Content Gate (HARD STOP)** — Scan your full output from this session before calling `/prd`.
+   The PRD must contain **only** requirements and design decisions. Strip anything that qualifies as:
+   - Implementation details (function signatures, variable names, struct/array definitions)
+   - Code snippets (any fenced code block in C, Python, or pseudocode)
+   - File-level task breakdowns (e.g., "Step 1: write `src/foo.c`", numbered implementation steps)
+   If any of the above are found, **remove them now** before proceeding.
+   Only continue to step 8 after this scan is clean.
+8. **Create GitHub issue** — use `/prd` skill to create a GitHub issue with the design as a PRD.
    Do NOT save a local design doc file. The GitHub issue IS the design doc.
-8. **Transition to implementation** — invoke the `writing-plans` skill (`Skill` tool, `skill: "writing-plans"`) to create the implementation plan
+9. **Transition to implementation** — invoke the `writing-plans` skill (`Skill` tool, `skill: "writing-plans"`) to create the implementation plan
 
 ## GB Constraint Checklist
 
@@ -76,7 +83,12 @@ digraph brainstorming {
     "Unresolved items?" [shape=diamond];
     "Resolved/Unresolved/Deferred summary" -> "Unresolved items?";
     "Unresolved items?" -> "Ask clarifying questions" [label="yes, resolve first"];
-    "Unresolved items?" -> "Create GitHub issue with /prd" [label="no"];
+    "Unresolved items?" -> "PRD Content Gate" [label="no"];
+    "PRD Content Gate" [shape=box label="PRD Content Gate\n(strip impl details/code/task breakdowns)"];
+    "Implementation details found?" [shape=diamond];
+    "PRD Content Gate" -> "Implementation details found?";
+    "Implementation details found?" -> "PRD Content Gate" [label="yes, strip and re-scan"];
+    "Implementation details found?" -> "Create GitHub issue with /prd" [label="no, clean"];
     "Create GitHub issue with /prd" -> "Invoke writing-plans skill";
 }
 ```

--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -81,7 +81,9 @@ digraph process {
     "More tasks?" -> "Dispatch implementer subagent" [label="yes"];
     "More tasks?" -> "Dispatch final code reviewer" [label="no"];
     "Dispatch final code reviewer" -> "bank-post-build + gb-memory-validator + smoketest";
-    "bank-post-build + gb-memory-validator + smoketest" -> "Use superpowers:finishing-a-development-branch";
+    "bank-post-build + gb-memory-validator + smoketest" -> "Pre-PR Gate";
+    "Pre-PR Gate" [shape=box label="Pre-PR Gate\n(make test + clean build +\nno removed includes + no hardcoded values)"];
+    "Pre-PR Gate" -> "Use superpowers:finishing-a-development-branch";
 }
 ```
 
@@ -156,7 +158,20 @@ After all tasks are complete and the final code reviewer approves, run the post-
    ```
    Tell the user it's running. Wait for their confirmation before proceeding.
 
-Only after smoketest confirmed: use `superpowers:finishing-a-development-branch`.
+Only after smoketest confirmed, run the **Pre-PR Gate** before calling `finishing-a-development-branch`.
+
+## Pre-PR Gate (HARD STOP)
+
+Run after smoketest is confirmed and before pushing or creating a PR. All checks must pass.
+
+| # | Check | How to verify | On failure |
+|---|-------|---------------|------------|
+| 1 | **Full test suite passes** | `make test` → all tests PASS (no early-exit failures) | Fix failing test, re-run from scratch |
+| 2 | **Clean build succeeds** | `make clean && GBDK_HOME=/home/mathdaman/gbdk make` → zero errors | Fix compiler error before continuing |
+| 3 | **No header includes silently removed** | `git diff master...HEAD -- src/*.h` — every `#include` removal must be intentional and traceable to a task requirement | Restore removed include or justify removal in a commit comment |
+| 4 | **No hardcoded values introduced** | `git diff master...HEAD -- src/*.c src/*.h` — no magic numeric literals that should be constants in `config.h` | Replace with named constant, commit |
+
+If any check fails: fix and re-run from step 1 of this gate. Only proceed to `finishing-a-development-branch` after all four pass.
 
 ## Final Code Reviewer Dispatch
 

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -256,6 +256,20 @@ git commit -m "feat: add/update X"
 
 **Note for plan authors:** The `executing-plans` skill includes a final "Lessons Learned" step (Step 7) that runs after the smoketest passes. The implementer will ask the user whether any lessons should be captured as documentation updates (CLAUDE.md, memory, skills, or agents). No action is needed in the plan itself — this gate runs automatically at execution time.
 
+## Plan Self-Review Checklist (HARD STOP before presenting to user)
+
+Before offering the execution handoff, run this checklist. Fix any failures before proceeding.
+
+| # | Check | Pass criteria |
+|---|-------|---------------|
+| 1 | **No hardcoded values** | Every numeric constant, tile index, capacity, or coordinate is sourced from `config.h`, a Tiled export, or an explicit named constant — never a magic number |
+| 2 | **All tasks have explicit test criteria** | Every task states exactly how to verify it passes (command + expected output, or visual check description) |
+| 3 | **Parallel annotations complete** | Every task has `**Depends on:**` and `**Parallelizable with:**` filled in (not left as "none" without consideration) |
+| 4 | **Parallel Execution Groups tables present** | Every batch that precedes a Smoketest Checkpoint has a `#### Parallel Execution Groups` table |
+| 5 | **No implementation details leaked from brainstorming** | Plan contains file paths and task steps, not design narrative or requirement rationale (those belong in the GitHub issue) |
+
+If any check fails: fix the plan now, then re-run the checklist from the top.
+
 ## Execution Handoff
 
 After saving the plan, offer execution choice:


### PR DESCRIPTION
## Summary
- `brainstorming`: adds a hard-stop PRD Content Gate (step 7) before `/prd` — scans output and strips implementation details, code snippets, and file-level task breakdowns
- `writing-plans`: adds a Plan Self-Review Checklist before Execution Handoff — checks for hardcoded values, missing test criteria, and unfilled parallel annotations
- `subagent-driven-development`: adds a Pre-PR Gate after smoketest confirmation — verifies `make test` passes, clean build succeeds, no header includes silently removed, no hardcoded values introduced

## Test Plan
- [x] ROM builds cleanly (`make clean && GBDK_HOME=~/gbdk make`) — 64K, zero errors
- [x] All unit tests pass (`make test`) — 0 failures
- [x] Smoketest confirmed in Emulicious

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)