### PR TITLE
chore: wire headless-debug skill into debug workflow (explicit opt-in)

### DIFF
--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -94,6 +94,7 @@ When a hypothesis is **Confirmed** (or when instrumentation requires domain expe
 | Regression ("worked in PR X, broken now") | `compare-prs` skill | Sequential |
 | Runtime memory / registers / VRAM | `emulicious-debug` agent | Single |
 | Compile error / GBDK API misuse | `gbdk-expert` agent | Single |
+| Timing / WRAM state bug, user says "use headless" | `headless-debug` skill | Single — explicit opt-in only |
 
 **Conflicting findings:** When parallel agents return contradictory conclusions, surface both findings to the user verbatim and ask for direction. Do NOT attempt to reconcile conflicting findings autonomously.
 
@@ -124,6 +125,7 @@ When triggered:
 
 - **`emulicious-debug`** agent — step-through debugger, EMU_printf, memory/tile/sprite inspection, tracer, profiler
 - **`/compare-prs <N>`** skill — for "worked in PR X, broken now" hypotheses: builds both, lets you compare ROMs and diffs side-by-side
+- **`headless-debug`** skill — autonomous PyBoy loop for timing/WRAM bugs; invoke only when user explicitly requests headless debugging
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ Always use `gh` for git push/pull and GitHub operations. Run `gh auth setup-git`
 - **`bank-post-build`** — Documents the post-build bank validation. **Now fires automatically via PostToolUse hook** after every non-clean `make` — no manual invocation needed. Keep as fallback reference.
 - **`test`** — TDD red/green gate: run host-side unit tests with gcc + Unity.
 - **`prd`** — Create a GitHub issue with a PRD for a new feature.
+- **`headless-debug`** — Autonomous 5-step debug loop using PyBoy headless emulator — boot ROM, simulate inputs, read WRAM debug log, hypothesize, fix, verify. **Explicit opt-in only** — invoke when user says "use headless" or similar; requires `make build-debug` + `tests/integration/helpers.py`.
 
 ### Project-local shadows/extensions of global superpowers skills
 


### PR DESCRIPTION
## Summary
- Adds `headless-debug` row to `systematic-debugging` routing table — triggered only when user explicitly says "use headless"
- Adds `headless-debug` to Instrumentation Tools section of the same skill
- Adds `headless-debug` to `CLAUDE.md` Skills section for discoverability

## Test plan
- [ ] Confirmed ROM builds clean and smoketest passes
- [ ] No existing routing table entries changed (AC4)

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)