### PR TITLE
chore: pre-commit build gate hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "ROOT=$(git rev-parse --show-toplevel) && make -C \"$ROOT\" clean && GBDK_HOME=/home/mathdaman/gbdk make -C \"$ROOT\"",
+            "timeout": 120,
+            "statusMessage": "Pre-commit build gate: clean build..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.json` (project-scoped) with a `PreToolUse` hook that fires on `Bash(git commit*)` commands
- Runs `make clean && GBDK_HOME=/home/mathdaman/gbdk make` from the repo/worktree root before every Claude-made commit
- Blocks the commit and surfaces build errors if the ROM fails to compile

## Test plan
- [ ] Introduce a deliberate compile error in a `.c` file, attempt a commit — verify it is blocked with the build error visible
- [ ] Revert the error, attempt a commit — verify it succeeds without being blocked
- [ ] Run from a worktree directory — verify `git rev-parse --show-toplevel` resolves to the worktree root, not main repo

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)