### PR TITLE
docs: make grill-me a hard always-on gate in prd and writing-plans

### DIFF
--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -5,9 +5,7 @@ description: Use when creating a new PRD for a feature — creates a GitHub issu
 
 ## Before You Begin
 
-If there is an approved design from a brainstorming session, proceed directly to drafting.
-
-If not, invoke the `grill-me` skill before drafting — it will surface requirements, acceptance criteria, scope, and GB hardware constraints. Once grill-me is satisfied, proceed.
+Always invoke the `grill-me` skill — it will surface requirements, acceptance criteria, scope, and GB hardware constraints. Once grill-me is satisfied, proceed to drafting.
 
 ---
 

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -15,10 +15,6 @@ Assume they are a skilled developer, but know almost nothing about our toolset o
 
 ## Before You Begin
 
-If there is an approved design or a GitHub issue with a PRD in this conversation, proceed directly to writing the plan.
-
-If not, invoke the `grill-me` skill first — it will surface requirements, acceptance criteria, scope, and GB hardware constraints. Once grill-me is satisfied, proceed.
-
 **First action before anything else:** Pull and merge latest master into the current worktree branch:
 ```bash
 git fetch origin && git merge origin/master
@@ -28,6 +24,8 @@ Resolve any conflicts before proceeding.
 **Context:** This should be run in a dedicated worktree (created by brainstorming skill).
 
 **Save plans to:** `docs/plans/YYYY-MM-DD-<feature-name>.md`
+
+**Last step before writing:** Always invoke the `grill-me` skill — it will surface requirements, acceptance criteria, scope, and GB hardware constraints. Once grill-me is satisfied, proceed to writing the plan.
 
 ## Hard Gate Sequence
 


### PR DESCRIPTION
## Summary
- `prd` skill: grill-me is now always invoked as the last step before drafting (removed conditional bypass for existing brainstorm)
- `writing-plans` skill: grill-me is now always the last step before writing begins (after git fetch/merge setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)