### PR TITLE
feat: improve parallel agent usage across workflow skills

### DIFF
--- a/.claude/skills/dispatching-parallel-agents/SKILL.md
+++ b/.claude/skills/dispatching-parallel-agents/SKILL.md
@@ -69,6 +69,22 @@ When a plan flags tasks as parallelizable (different output files, no shared sta
 
 **Batch size limit:** Max 3 concurrent implementers. More than 3 creates coordination overhead that exceeds the parallelism benefit.
 
+## Look-Ahead Batch Rule
+
+**Before firing ANY agent** — whether executing a formal plan or doing ad-hoc multi-step work — scan the next 1–2 steps:
+
+1. Do the next steps produce different output files?
+2. Do they have no sequential data dependency (step N+1 does not need step N's output)?
+
+If both are true: **batch them in the same message.** Do not run them sequentially out of habit.
+
+This rule applies to ALL sequential multi-step work — not just tasks flagged as parallelizable in a formal plan. Ad-hoc investigations, doc edits, read-only explorations, and review dispatches all qualify.
+
+**Example:**
+- About to run spec reviewer, about to run quality reviewer → same message.
+- About to read `src/player.c`, about to read `src/enemy.c` to understand a system → single Explore agent.
+- About to update `sprite-expert/SKILL.md`, about to update `map-expert/SKILL.md` → single message with two Edit calls.
+
 ## Red Flags
 
 These thoughts mean STOP and check this skill:
@@ -80,6 +96,7 @@ These thoughts mean STOP and check this skill:
 | "I'll dispatch the quality reviewer after the spec reviewer finishes" | Fire both in one message |
 | "These two tasks write different files, I'll run them sequentially" | They're parallelizable — single message |
 | "I'll let both implementers commit to the branch at once" | Race condition — coordinate |
+| "This is ad-hoc work, not a formal plan, so I don't need to parallelize" | Look-ahead batch rule applies to ALL multi-step work |
 
 ## Integration
 

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -46,9 +46,15 @@ NEVER use `git merge master` alone — the local master ref may be stale. Resolv
 
 ### Step 4: Execute Batch
 
-**Default: first 3 tasks (or all remaining if fewer than 3)**
+**Before dispatching any task, read the parallel dispatch source of truth (priority order):**
 
-For each task:
+1. **Primary:** Find the `#### Parallel Execution Groups` table for the current batch in the plan. Dispatch all tasks in a `(parallel)` group as concurrent implementer Agent calls in a **single message** (max 3).
+2. **Fallback:** If no group table exists, scan each task's `**Parallelizable with:**` annotation. Batch tasks that name each other into a single message.
+3. **Last resort:** If neither exists, run tasks sequentially.
+
+**Batch atomicity rule (HARD):** If ANY implementer in a parallel group fails, halt the entire batch immediately. Passing implementers MUST discard their in-progress work — do NOT stage or commit partial results. Fix the failure, then re-dispatch the entire group from scratch.
+
+For each task (whether parallel or sequential):
 1. Mark as in_progress
 2. Follow each step exactly (plan has bite-sized steps)
 3. Before writing any `src/*.c` or `src/*.h` file:
@@ -150,6 +156,7 @@ Do not push or open the PR until you have received an explicit answer to this qu
 - bank-post-build gate after every build
 - Smoketest uses Emulicious, not mgba-qt
 - Merge command is `git fetch origin && git merge origin/master`
+- Parallel implementers: read `#### Parallel Execution Groups` table first; dispatch parallel groups as concurrent Agent calls (max 3); batch atomicity — if any fails, ALL discard and retry from scratch
 - Parallel reviewers: fire spec + quality in one message after each implementer commit (see dispatching-parallel-agents)
 - Explore agent: use for any codebase exploration > 2 files (see dispatching-parallel-agents)
 

--- a/.claude/skills/finishing-a-development-branch/SKILL.md
+++ b/.claude/skills/finishing-a-development-branch/SKILL.md
@@ -15,9 +15,25 @@ Guide completion of development work by presenting clear options and handling ch
 
 ## The Process
 
-### Step 1: Verify Tests
+### Step 1: Concurrent batch — fetch/merge + bank manifest review
 
-**Before presenting options, verify tests pass:**
+Run these two operations as a **concurrent batch** (dispatch in a single message / start both in parallel):
+
+**1a. Fetch and merge latest master** (mandatory — always run, even for doc-only branches):
+```bash
+git fetch origin && git merge origin/master
+```
+If merge conflicts occur: resolve them now, commit the merge, then continue. Do NOT push until the merge is clean.
+
+**1b. Bank manifest review** (parallel with 1a — read-only, no merge dependency):
+
+Check `bank-manifest.json` against `src/*.c` files in the branch: every `src/*.c` file must have an entry. Flag any missing entries as a blocker before proceeding.
+
+Wait for **both** 1a and 1b to complete before moving to Step 2.
+
+### Step 2: Verify Tests (sequential — must run against merged state)
+
+**Run after Step 1 completes** (tests must execute against the merged codebase):
 
 ```bash
 make test
@@ -32,19 +48,9 @@ Tests failing (<N> failures). Must fix before completing:
 Cannot proceed with merge/PR until tests pass.
 ```
 
-Stop. Don't proceed to Step 2.
+Stop. Don't proceed to Step 3.
 
-**If tests pass:** Continue to Step 2.
-
-### Step 2: Merge latest master (mandatory — always run this, even for doc-only branches)
-
-```bash
-git fetch origin && git merge origin/master
-```
-
-**If merge conflicts occur:** resolve them now, commit the merge, then continue. Do NOT push until the merge is clean. This is the step that catches divergence before it becomes a PR conflict.
-
-**If fast-forward or clean merge:** continue to Step 3.
+**If tests pass:** Continue to Step 3.
 
 ### Step 3: HARD GATE — bank-post-build
 
@@ -58,7 +64,7 @@ Only continue to Step 4 when it passes.
 
 **Skip this step for doc-only branches** (no `src/*.c`, `src/*.h`, or asset changes) — go directly to Step 5.
 
-1. Always do a clean build (master is already merged from Step 2):
+1. Always do a clean build (master is already merged from Step 1):
    ```bash
    make clean && GBDK_HOME=/home/mathdaman/gbdk make
    ```
@@ -265,14 +271,14 @@ Run the same Step 6a → 6b → 6c sequence immediately after the user types 'di
 - Skip bank-post-build or `make memory-check` before smoketest
 - Clean up worktree immediately after PR creation (wait for merge confirmation)
 - Skip Step 4.5 when skills, agents, or CLAUDE.md were modified
-- Push without running Step 2 — even doc-only branches can have conflicts
+- Push without running Step 1 (fetch/merge) — even doc-only branches can have conflicts
 
 **Always:**
 - Work on a feature branch
 - Integrate via PR only
 - Verify tests before offering options
 - Run bank-post-build + `make memory-check` before smoketest
-- Fetch + merge origin/master at Step 2 — unconditionally, before any build or push
+- Fetch + merge origin/master at Step 1 (concurrent with manifest review) — unconditionally, before any build or push
 - Launch Emulicious from worktree directory
 - Present exactly 3 options
 - Get typed confirmation for Option 3

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -22,13 +22,22 @@ If the user has already described the bug, skip questions that are already answe
 
 ## Step 2: Explore the Codebase
 
-Before proposing a root cause, explore the code:
-- Find the relevant module (`src/<module>.c`) and its header
-- Identify which ROM bank the module is in (check `bank-manifest.json` or `#pragma bank` in the file)
-- Trace the execution path from input to symptom
-- Check for related tests in `tests/test_<module>.c`
+Before proposing a root cause, dispatch a **single Explore agent** (Agent tool, `subagent_type: "Explore"`) to investigate. Do NOT perform inline Read/Glob/Grep calls — offload the entire exploration to the agent.
 
-Ask one clarifying question at a time if the codebase exploration doesn't resolve ambiguity.
+The agent prompt MUST request all four fields in a structured return:
+
+```
+Investigate the bug described below and return EXACTLY these four fields:
+
+- **Module:** `src/<module>.c` (the primary file containing the defect)
+- **Bank:** N (from `bank-manifest.json` or `#pragma bank` in the file)
+- **Execution path:** function-call chain from the trigger (input/state change) to the symptom location
+- **Test file:** `tests/test_<module>.c` (or "none" if absent)
+
+Bug description: <paste symptom from Step 1>
+```
+
+Use the four-field response as input for Step 3. Ask one clarifying question at a time if the Explore agent's response does not resolve ambiguity.
 
 ## Step 3: Identify Root Cause
 

--- a/.claude/skills/writing-plans/SKILL.md
+++ b/.claude/skills/writing-plans/SKILL.md
@@ -268,11 +268,28 @@ Before offering the execution handoff, run this checklist. Fix any failures befo
 |---|-------|---------------|
 | 1 | **No hardcoded values** | Every numeric constant, tile index, capacity, or coordinate is sourced from `config.h`, a Tiled export, or an explicit named constant — never a magic number |
 | 2 | **All tasks have explicit test criteria** | Every task states exactly how to verify it passes (command + expected output, or visual check description) |
-| 3 | **Parallel annotations complete** | Every task has `**Depends on:**` and `**Parallelizable with:**` filled in (not left as "none" without consideration) |
+| 3 | **Parallel annotations justified** | Every task has `**Depends on:**` and `**Parallelizable with:**` filled in. Any `**Parallelizable with:** none` MUST be followed by a one-sentence justification (e.g., "writes same file as Task M", "requires Task M's output symbol"). An unjustified `none` is a plan defect. |
 | 4 | **Parallel Execution Groups tables present** | Every batch that precedes a Smoketest Checkpoint has a `#### Parallel Execution Groups` table |
 | 5 | **No implementation details leaked from brainstorming** | Plan contains file paths and task steps, not design narrative or requirement rationale (those belong in the GitHub issue) |
 
-If any check fails: fix the plan now, then re-run the checklist from the top.
+**Failure handling:**
+- Checks #1, #2, #4, #5 fail → fix the plan now and re-run the checklist from the top.
+- Check #3 fails (unjustified `none`) → do NOT silently fix. Present the plan WITH the Incomplete Warning block below, immediately after the plan header. The user decides whether to proceed or fix first.
+
+### Incomplete Warning Block (use when check #3 fails)
+
+```markdown
+> ⚠️ **Plan incomplete — unjustified parallelism annotations**
+>
+> The following tasks have `**Parallelizable with:** none` with no justification sentence:
+> - Task N: [task name]
+>
+> For each: either (a) identify tasks it can parallelize with and update the annotation,
+> or (b) add a one-sentence justification explaining why it cannot parallelize
+> (e.g., "writes same file as Task M", "requires Task M's output symbol").
+>
+> Proceed with the plan as-is, or fix these annotations first?
+```
 
 ## Execution Handoff
 


### PR DESCRIPTION
## Summary

- `writing-plans`: unjustified `**Parallelizable with:** none` now flags the plan as incomplete with a visible warning block — user decides whether to proceed or fix first
- `executing-plans`: reads `#### Parallel Execution Groups` table before dispatch; parallel groups fire as concurrent Agent calls (max 3); batch atomicity — any failure halts all, passing implementers discard work (no partial commits)
- `triage-issue`: Step 2 replaced with a single Explore agent dispatch requiring structured 4-field return (module, bank, execution path, test file)
- `finishing-a-development-branch`: Step 1 is now a concurrent batch of `git fetch/merge` + bank manifest review; `make test` runs sequentially after the merge completes
- `dispatching-parallel-agents`: adds Look-Ahead Batch Rule for all multi-step work (not just formal plans); new Red Flags row for ad-hoc work

## Test Plan
- [ ] Doc-only changes — no `.c`/`.h` files touched
- [ ] Clean ROM build passes
- [ ] Emulicious smoketest confirmed by user

Closes #244