### PR TITLE
fix: absolute hook paths and GIT_DIR for worktree cleanup

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -301,7 +301,8 @@
       "Bash(python3 tests/integration/diagnose_audio.py)",
       "Bash(make bank-post-build:*)",
       "Bash(git push:*)",
-      "Bash(find /home/mathdaman/code/nuke-raider/lib/hUGEDriver -type f \\\\\\(-name *.c -o -name *.s -o -name *.asm \\\\\\))"
+      "Bash(find /home/mathdaman/code/nuke-raider/lib/hUGEDriver -type f \\\\\\(-name *.c -o -name *.s -o -name *.asm \\\\\\))",
+      "Bash(read current working directory\" errors after worktree removal:*)"
     ]
   },
   "hooks": {
@@ -311,7 +312,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 tools/bank_check_hook.py",
+            "command": "python3 /home/mathdaman/code/nuke-raider/tools/bank_check_hook.py",
             "statusMessage": "bank-pre-write check..."
           }
         ]
@@ -323,7 +324,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 tools/post_build_hook.py",
+            "command": "python3 /home/mathdaman/code/nuke-raider/tools/post_build_hook.py",
             "statusMessage": "bank-post-build + memory-check..."
           }
         ]

--- a/.claude/skills/finishing-a-development-branch/SKILL.md
+++ b/.claude/skills/finishing-a-development-branch/SKILL.md
@@ -187,23 +187,25 @@ Only run after the user explicitly confirms the PR was merged — **never preemp
 
 **Step 6a: Confirm worktree exists**
 ```bash
-git worktree list | grep <branch-name>
+GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree list | grep <branch-name>
 ```
 If not listed, skip removal (already gone).
 
 **Step 6b: Remove the worktree**
+
+Always use explicit `GIT_DIR` — the session CWD may be inside or point to the deleted worktree, which causes bare `git` commands to fail:
 ```bash
-git worktree remove <worktree-path>
+GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree remove <worktree-path>
 ```
 If that fails (e.g. dirty working tree), use `--force` and warn the user:
 ```bash
-git worktree remove --force <worktree-path>
+GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree remove --force <worktree-path>
 # Warn: "Worktree had uncommitted changes — removed with --force."
 ```
 
 **Step 6c: Prune stale refs**
 ```bash
-git worktree prune
+GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree prune
 ```
 
 Report: "Worktree at `<path>` removed and pruned."


### PR DESCRIPTION
## Summary

- `settings.local.json`: both hooks (`bank_check_hook.py`, `post_build_hook.py`) now use absolute paths — fixes "No such file or directory" errors when the session CWD is a stale/deleted worktree directory
- `finishing-a-development-branch`: Step 7 remove/prune commands now always use `GIT_DIR=...` — fixes "Unable to read current working directory" errors when cleaning up after a merged PR

## Test Plan
- [ ] Doc-only / config-only changes — no `.c`/`.h` files touched
- [ ] Clean ROM build passes
- [ ] Smoketest confirmed