### PR TITLE
fix: reliable worktree cleanup + mandatory headless test gate

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -303,7 +303,9 @@
       "Bash(git push:*)",
       "Bash(find /home/mathdaman/code/nuke-raider/lib/hUGEDriver -type f \\\\\\(-name *.c -o -name *.s -o -name *.asm \\\\\\))",
       "Bash(read current working directory\" errors after worktree removal:*)",
-      "Bash(wc -l /home/mathdaman/code/nuke-raider/tests/test_*.c /home/mathdaman/code/nuke-raider/tests/test_*.py)"
+      "Bash(wc -l /home/mathdaman/code/nuke-raider/tests/test_*.c /home/mathdaman/code/nuke-raider/tests/test_*.py)",
+      "Bash(GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree remove /home/mathdaman/code/nuke-raider/.claude/worktrees/plan-issue-248-headless-regression)",
+      "Bash(GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree remove --force /home/mathdaman/code/nuke-raider/.claude/worktrees/plan-issue-248-headless-regression)"
     ]
   },
   "hooks": {

--- a/.claude/skills/finishing-a-development-branch/SKILL.md
+++ b/.claude/skills/finishing-a-development-branch/SKILL.md
@@ -9,7 +9,7 @@ description: Use when implementation is complete, all tests pass, and you need t
 
 Guide completion of development work by presenting clear options and handling chosen workflow.
 
-**Core principle:** Verify tests → Merge master → Bank gates → Smoketest → Present options → Execute choice → Clean up.
+**Core principle:** Verify tests → Merge master → Bank gates → Headless tests → Smoketest → Present options → Execute choice → Clean up.
 
 **Announce at start:** "I'm using the finishing-a-development-branch skill to complete this work."
 
@@ -60,9 +60,17 @@ Invoke the `bank-post-build` skill. If it reports any FAIL, stop and fix before 
 
 Only continue to Step 4 when it passes.
 
-### Step 4: Smoketest in Emulicious
+### Step 4: Headless Integration Tests
 
-**Skip this step for doc-only branches** (no `src/*.c`, `src/*.h`, or asset changes) — go directly to Step 5.
+**Skip this step for doc-only branches** (no `src/*.c`, `src/*.h`, or asset changes) — go directly to Step 4.5.
+
+Invoke the `test-integration` skill. If it reports any failure, stop and fix before continuing.
+
+Only continue to Step 4.5 when it passes.
+
+### Step 4.5: Smoketest in Emulicious
+
+**Skip this step for doc-only branches** (no `src/*.c`, `src/*.h`, or asset changes) — go directly to Step 4.6.
 
 1. Always do a clean build (master is already merged from Step 1):
    ```bash
@@ -83,9 +91,9 @@ Only continue to Step 4 when it passes.
 **Stop. Wait for explicit confirmation.**
 
 - If issues found: work with user to fix before continuing
-- If confirmed: Continue to Step 4.5
+- If confirmed: Continue to Step 4.6
 
-### Step 4.5: Update Docs Before PR
+### Step 4.6: Update Docs Before PR
 
 Before presenting options, check what changed in this branch:
 
@@ -170,11 +178,14 @@ Wait for exact confirmation.
 If confirmed, remove the worktree first, then delete the branch from the main repo:
 
 ```bash
-# Step 1: Remove the worktree (from inside the worktree — git worktree remove works)
-git worktree remove --force <worktree-path>
+# Step 1: cd to main repo root (CWD may be inside the worktree)
+cd /home/mathdaman/code/nuke-raider
 
-# Step 2: Delete the branch from the main repo
-git -C /home/mathdaman/code/gmb-nuke-raider branch -D <feature-branch>
+# Step 2: Remove the worktree
+GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree remove --force <worktree-path>
+
+# Step 3: Delete the branch from the main repo
+git -C /home/mathdaman/code/nuke-raider branch -D <feature-branch>
 ```
 
 Then run Step 7 immediately.
@@ -191,9 +202,15 @@ GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code
 ```
 If not listed, skip removal (already gone).
 
-**Step 6b: Remove the worktree**
+**Step 6b: cd to main repo root**
 
-Always use explicit `GIT_DIR` — the session CWD may be inside or point to the deleted worktree, which causes bare `git` commands to fail:
+Always do this before any removal command. The session CWD may be inside the worktree — if that directory is already deleted, `git` will panic with "Unable to read current working directory":
+```bash
+cd /home/mathdaman/code/nuke-raider
+```
+
+**Step 6c: Remove the worktree**
+
 ```bash
 GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree remove <worktree-path>
 ```
@@ -202,8 +219,15 @@ If that fails (e.g. dirty working tree), use `--force` and warn the user:
 GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree remove --force <worktree-path>
 # Warn: "Worktree had uncommitted changes — removed with --force."
 ```
+If `--force` also fails (directory already deleted from disk, stale git ref), clean up manually:
+```bash
+rm -rf <worktree-path>
+GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree prune
+# Note: "Worktree directory was already gone — pruned stale ref."
+```
+Skip Step 6d in this case (prune already ran).
 
-**Step 6c: Prune stale refs**
+**Step 6d: Prune stale refs**
 ```bash
 GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree prune
 ```
@@ -212,7 +236,7 @@ Report: "Worktree at `<path>` removed and pruned."
 
 #### Immediately after discard confirmation (Option 3)
 
-Run the same Step 6a → 6b → 6c sequence immediately after the user types 'discard'.
+Run the same Step 6a → 6b → 6c → 6d sequence immediately after the user types 'discard'. Skip Step 6b if already at main repo root.
 
 #### Option 2: Keep As-Is
 
@@ -244,12 +268,13 @@ Run the same Step 6a → 6b → 6c sequence immediately after the user types 'di
 - **Problem:** Local master ref may be stale; silently merges old code
 - **Fix:** Always `git fetch origin && git merge origin/master`
 
-**`git worktree prune` fails when session CWD is the deleted worktree**
-- **Problem:** After `git worktree remove`, if the session's working directory was inside that worktree, `git worktree prune` (and bare `git` commands) fail with "Working directory no longer exists"
-- **Fix:** Use explicit `GIT_DIR` to target the main repo:
-  ```bash
-  GIT_DIR=/home/mathdaman/code/nuke-raider/.git GIT_WORK_TREE=/home/mathdaman/code/nuke-raider git worktree prune
-  ```
+**`git worktree remove` fails with "Unable to read current working directory"**
+- **Problem:** Session CWD is inside the worktree being removed — git calls `getcwd()` internally and panics when the directory is already deleted
+- **Fix:** Always `cd /home/mathdaman/code/nuke-raider` before any `git worktree remove` command (Step 6b)
+
+**`git worktree remove --force` fails with "is not a working tree"**
+- **Problem:** The worktree directory was already deleted from disk, leaving a stale git ref
+- **Fix:** Fall back to `rm -rf <path> && git worktree prune` to clean up the stale ref
 
 **Merging directly to main**
 - **Problem:** Bypasses review, violates branch policy
@@ -286,7 +311,8 @@ Run the same Step 6a → 6b → 6c sequence immediately after the user types 'di
 - Get typed confirmation for Option 3
 - Update `docs/dev-workflow.md` in the same PR as any skill/agent/CLAUDE.md change
 - After PR creation (Option 1): tell user the worktree path and ask them to confirm when merged
-- After merge confirmation: run git worktree remove → --force fallback → git worktree prune
+- Run headless integration tests (`make test-integration`) before presenting options — mandatory for non-doc-only branches
+- After merge confirmation: cd to main repo root → git worktree remove → --force fallback → rm -rf + prune fallback → git worktree prune
 
 ## Integration
 

--- a/.claude/skills/test-integration/SKILL.md
+++ b/.claude/skills/test-integration/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: test-integration
+description: Use this skill to run headless integration tests. Triggers during regression debugging, when any state transition or game logic changes, and as a mandatory gate in finishing-a-development-branch before the Emulicious smoketest. Boots the ROM headlessly via PyBoy through all game states.
+---
+
+Run `make test-integration`.
+
+This builds the debug ROM (`make build-debug`) then runs `tests/integration/test_regression.py` via pytest, booting the ROM headlessly through every game state (Title → Overmap → Hub → Playing → Game Over → Title).
+
+On success: report "Integration tests OK — all states passed".
+
+On failure: list each failing test with name and error. Common causes:
+
+- **ROM not found / Map file not found**: the debug ROM wasn't built — run `make build-debug` first, then retry
+- **`KeyError: Symbol '_hp' not found`**: SDCC emitted a different symbol name — run `grep '_hp' build/nuke-raider.map` to find the actual name and update `test_regression.py`
+- **Test hangs / timeout**: a frame budget constant is too small for a state transition — increase the relevant `_*_NAV_FRAMES` constant in `test_regression.py`
+- **PyBoy import error**: run `pip install pyboy` to install the dependency


### PR DESCRIPTION
## Summary
- `cd` to main repo root before `git worktree remove` to prevent `getcwd()` panic when session CWD is inside a deleted worktree
- Add `rm -rf + git worktree prune` fallback when `--force` also fails (stale git ref, directory already gone)
- Add `test-integration` skill wrapping `make test-integration` (parallel to existing `/test` unit test skill)
- Add headless integration tests as Step 4 gate in `finishing-a-development-branch`, running before the Emulicious smoketest

## Test Plan
- [ ] make test passes
- [ ] Doc-only branch — smoketest and headless gates skipped per policy