### PR TITLE
refactor: extend TrackDesc with load_tiles fn ptr, replace if/else in track_init

### DIFF
--- a/src/track.c
+++ b/src/track.c
@@ -10,9 +10,9 @@ extern const int16_t track3_start_y;
 extern const uint8_t track3_map[];
 
 static const TrackDesc track_table[] = {
-    { track_map,  &track_start_x,  &track_start_y,  1u, &track_map_type,  TRACK1_REWARD },
-    { track2_map, &track2_start_x, &track2_start_y, 3u, &track2_map_type, TRACK2_REWARD },
-    { track3_map, &track3_start_x, &track3_start_y, 1u, &track3_map_type, 0u           },
+    { track_map,  &track_start_x,  &track_start_y,  1u, &track_map_type,  TRACK1_REWARD, load_track_tiles  },
+    { track2_map, &track2_start_x, &track2_start_y, 3u, &track2_map_type, TRACK2_REWARD, load_track2_tiles },
+    { track3_map, &track3_start_x, &track3_start_y, 1u, &track3_map_type, 0u,            load_track3_tiles },
 };
 
 /* Tile index → TileType lookup table — static const is linked into ROM by SDCC on sm83 */
@@ -87,13 +87,7 @@ TileType track_tile_type(int16_t world_x, int16_t world_y) BANKED {
 }
 
 void track_init(void) BANKED {
-    if (active_track_id == 0u) {
-        load_track_tiles();
-    } else if (active_track_id == 1u) {
-        load_track2_tiles();
-    } else {
-        load_track3_tiles();
-    }
+    track_table[active_track_id].load_tiles();
     /* Tilemap loaded by camera_init() */
     SHOW_BKG;
 }

--- a/src/track.h
+++ b/src/track.h
@@ -39,6 +39,7 @@ extern uint8_t active_map_h;
 
 #include "checkpoint.h"
 #include "banking.h"
+#include "loader.h"
 BANKREF_EXTERN(track_map)
 BANKREF_EXTERN(track_tile_data)
 BANKREF_EXTERN(track_start_x)
@@ -72,6 +73,7 @@ typedef struct {
     uint8_t         lap_count;
     const uint8_t  *map_type;   /* points to track_map_type / track2_map_type / track3_map_type */
     uint16_t        reward;     /* scrap payout; TRACK1_REWARD / TRACK2_REWARD from config.h */
+    void (*load_tiles)(void);   /* NONBANKED tile loader — called by track_init() */
 } TrackDesc;
 
 /* Select active track before entering STATE_PLAYING.

--- a/tests/test_track_dispatch.c
+++ b/tests/test_track_dispatch.c
@@ -45,6 +45,29 @@ void test_track_select_0_checkpoint_count_is_zero(void) {
                 track_get_checkpoint_count() > 0u); /* just verifies accessor exists */
 }
 
+/* --- track_init() dispatches correct tile loader for each track --- */
+
+/* track_select(0) + track_init() must not crash (routes to load_track_tiles) */
+void test_track_init_track0_no_crash(void) {
+    track_select(0u);
+    track_init();
+    TEST_PASS();
+}
+
+/* track_select(1) + track_init() must not crash (routes to load_track2_tiles) */
+void test_track_init_track1_no_crash(void) {
+    track_select(1u);
+    track_init();
+    TEST_PASS();
+}
+
+/* track_select(2) + track_init() must not crash (routes to load_track3_tiles) */
+void test_track_init_track2_no_crash(void) {
+    track_select(2u);
+    track_init();
+    TEST_PASS();
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_track_select_0_start_x);
@@ -53,5 +76,8 @@ int main(void) {
     RUN_TEST(test_track_select_1_lap_count);
     RUN_TEST(test_track_select_routes_raw_tile);
     RUN_TEST(test_track_select_0_checkpoint_count_is_zero);
+    RUN_TEST(test_track_init_track0_no_crash);
+    RUN_TEST(test_track_init_track1_no_crash);
+    RUN_TEST(test_track_init_track2_no_crash);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Added `void (*load_tiles)(void)` field to `TrackDesc` struct in `src/track.h`
- Updated `track_table[]` initializer in `src/track.c` with one NONBANKED loader fn ptr per row
- Replaced 7-line `if/else` chain in `track_init()` with single `track_table[active_track_id].load_tiles()` dispatch — adding a 4th track now requires only a new row in `track_table`

## Test Plan
- [x] `make test` passes (9/9 tests including 3 new no-crash dispatch tests)
- [x] `make test-integration` passes (3/3 integration tests)
- [x] Emulicious smoketest confirmed — all 3 tracks load and play correctly
- [x] `bank-post-build`: ROM_0 71% PASS, ROM_1 99% WARN (pre-existing), ROM_2 64% PASS
- [x] `gb-memory-validator`: WRAM 10%, VRAM 5%, OAM 77% — all PASS

Closes #272