### PR TITLE
feat(loader): tile manager increment 1 — slot allocator + asset registry

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -239,9 +239,6 @@ static uint8_t loader_vram_bitmap[32];  /* zero-initialized (static storage) */
  * 0xFF = not yet allocated. Updated by Increment 2 (loader_load_asset). */
 static uint8_t loader_asset_slot[TILE_ASSET_COUNT];
 
-/* Bank-per-asset table — populated at runtime by loader_init_allocator().
- * BANK(sym) is a runtime expression in SDCC, not a constant initializer. */
-static uint8_t loader_asset_bank_tbl[TILE_ASSET_COUNT];
 
 #ifndef __SDCC
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank) {
@@ -259,20 +256,6 @@ void loader_init_allocator(void) NONBANKED {
     uint8_t i;
     for (i = 0u; i < 32u; i++) loader_vram_bitmap[i] = 0u;
     for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) loader_asset_slot[i] = 0xFFu;
-    /* Populate bank table at runtime — BANK(sym) is not a constant expression
-     * in SDCC, so this cannot be done as a static initializer. */
-    loader_asset_bank_tbl[TILE_ASSET_PLAYER]       = BANK(player_tile_data);
-    loader_asset_bank_tbl[TILE_ASSET_BULLET]        = BANK(bullet_tile_data);
-    loader_asset_bank_tbl[TILE_ASSET_TURRET]        = BANK(turret_tile_data);
-    loader_asset_bank_tbl[TILE_ASSET_OVERMAP_CAR]   = BANK(overmap_car_tile_data);
-    loader_asset_bank_tbl[TILE_ASSET_DIALOG_ARROW]  = BANK(dialog_arrow_tile_data);
-    loader_asset_bank_tbl[TILE_ASSET_TRACK]         = BANK(track_tile_data);
-    loader_asset_bank_tbl[TILE_ASSET_OVERMAP_BG]    = BANK(overmap_tile_data);
-    loader_asset_bank_tbl[TILE_ASSET_HUD_FONT]      = 0u; /* self-managed, fixed page */
-    loader_asset_bank_tbl[TILE_ASSET_NPC_DRIFTER]   = BANK(npc_drifter_portrait);
-    loader_asset_bank_tbl[TILE_ASSET_NPC_MECHANIC]  = BANK(npc_mechanic_portrait);
-    loader_asset_bank_tbl[TILE_ASSET_NPC_TRADER]    = BANK(npc_trader_portrait);
-    loader_asset_bank_tbl[TILE_ASSET_DIALOG_BORDER] = BANK(dialog_border_tiles);
 }
 
 uint8_t loader_alloc_slots(uint8_t region_start, uint8_t region_end, uint8_t count) NONBANKED {
@@ -280,23 +263,25 @@ uint8_t loader_alloc_slots(uint8_t region_start, uint8_t region_end, uint8_t cou
     uint8_t run;
     uint8_t start;
     uint8_t cap;
+    uint8_t slot;
     if (region_end > 254u) return 0xFFu;
     if (count == 0u) return 0xFFu;
     if (region_end < region_start) return 0xFFu;
-    /* cap: last valid start so that start+count-1 <= region_end */
+    /* cap: last valid start so that start+count-1 <= region_end.
+     * Safe from wrap: region_end <= 254 (enforced above), so cap <= 254. */
     if ((region_end - region_start + 1u) < count) return 0xFFu;
     cap = region_end - count + 1u;
     for (start = region_start; start <= cap; start++) {
         run = 0u;
         for (i = 0u; i < count; i++) {
-            uint8_t slot = start + i;
+            slot = start + i;
             if (loader_vram_bitmap[slot >> 3u] & (uint8_t)(1u << (slot & 7u))) break;
             run++;
         }
         if (run == count) {
             /* Mark bits occupied */
             for (i = 0u; i < count; i++) {
-                uint8_t slot = start + i;
+                slot = start + i;
                 loader_vram_bitmap[slot >> 3u] |= (uint8_t)(1u << (slot & 7u));
             }
             return start;
@@ -343,8 +328,21 @@ const tile_registry_entry_t *loader_get_registry(tile_asset_t asset) NONBANKED {
 }
 
 uint8_t loader_get_asset_bank(tile_asset_t asset) NONBANKED {
-    if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) return 0u;
-    return loader_asset_bank_tbl[(uint8_t)asset];
+    switch ((uint8_t)asset) {
+        case TILE_ASSET_PLAYER:        return BANK(player_tile_data);
+        case TILE_ASSET_BULLET:        return BANK(bullet_tile_data);
+        case TILE_ASSET_TURRET:        return BANK(turret_tile_data);
+        case TILE_ASSET_OVERMAP_CAR:   return BANK(overmap_car_tile_data);
+        case TILE_ASSET_DIALOG_ARROW:  return BANK(dialog_arrow_tile_data);
+        case TILE_ASSET_TRACK:         return BANK(track_tile_data);
+        case TILE_ASSET_OVERMAP_BG:    return BANK(overmap_tile_data);
+        case TILE_ASSET_HUD_FONT:      return 0u;
+        case TILE_ASSET_NPC_DRIFTER:   return BANK(npc_drifter_portrait);
+        case TILE_ASSET_NPC_MECHANIC:  return BANK(npc_mechanic_portrait);
+        case TILE_ASSET_NPC_TRADER:    return BANK(npc_trader_portrait);
+        case TILE_ASSET_DIALOG_BORDER: return BANK(dialog_border_tiles);
+        default:                       return 0u;
+    }
 }
 
 void load_npc_positions(uint8_t id,

--- a/src/loader.c
+++ b/src/loader.c
@@ -219,12 +219,77 @@ void loader_map_fill_col(uint8_t tx, uint8_t w, uint8_t h, uint8_t ty_start, uin
     SWITCH_ROM(saved);
 }
 
+/* ---- VRAM slot bitmap allocator ---- */
+
+/* 256-bit bitmap: bit N = VRAM slot N occupied.
+ * Slots 0-63: sprite region. Slots 64-254: BG region.
+ * Slot 255 is permanently reserved as the 0xFF failure sentinel — never allocated. */
+static uint8_t loader_vram_bitmap[32];  /* zero-initialized (static storage) */
+
+/* Asset-to-slot table: first allocated VRAM slot per tile_asset_t.
+ * 0xFF = not yet allocated. Updated by Increment 2 (loader_load_asset). */
+static uint8_t loader_asset_slot[TILE_ASSET_COUNT];
+
 #ifndef __SDCC
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank) {
     loader_active_map_ptr = map;
     loader_active_data_bank = data_bank;
 }
+void loader_reset_bitmap_for_test(void) {
+    uint8_t i;
+    for (i = 0u; i < 32u; i++) loader_vram_bitmap[i] = 0u;
+    for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) loader_asset_slot[i] = 0xFFu;
+}
 #endif
+
+void loader_init_allocator(void) NONBANKED {
+    uint8_t i;
+    for (i = 0u; i < 32u; i++) loader_vram_bitmap[i] = 0u;
+    for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) loader_asset_slot[i] = 0xFFu;
+}
+
+uint8_t loader_alloc_slots(uint8_t region_start, uint8_t region_end, uint8_t count) NONBANKED {
+    uint8_t i;
+    uint8_t run;
+    uint8_t start;
+    uint8_t cap;
+    if (region_end > 254u) return 0xFFu;
+    if (count == 0u) return 0xFFu;
+    if (region_end < region_start) return 0xFFu;
+    /* cap: last valid start so that start+count-1 <= region_end */
+    if ((region_end - region_start + 1u) < count) return 0xFFu;
+    cap = region_end - count + 1u;
+    for (start = region_start; start <= cap; start++) {
+        run = 0u;
+        for (i = 0u; i < count; i++) {
+            uint8_t slot = start + i;
+            if (loader_vram_bitmap[slot >> 3u] & (uint8_t)(1u << (slot & 7u))) break;
+            run++;
+        }
+        if (run == count) {
+            /* Mark bits occupied */
+            for (i = 0u; i < count; i++) {
+                uint8_t slot = start + i;
+                loader_vram_bitmap[slot >> 3u] |= (uint8_t)(1u << (slot & 7u));
+            }
+            return start;
+        }
+    }
+    return 0xFFu;
+}
+
+void loader_free_slots(uint8_t first_slot, uint8_t count) NONBANKED {
+    uint8_t i;
+    for (i = 0u; i < count; i++) {
+        uint8_t slot = first_slot + i;
+        loader_vram_bitmap[slot >> 3u] &= (uint8_t)~(uint8_t)(1u << (slot & 7u));
+    }
+}
+
+uint8_t loader_get_asset_slot(tile_asset_t asset) NONBANKED {
+    if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) return 0xFFu;
+    return loader_asset_slot[(uint8_t)asset];
+}
 
 void load_npc_positions(uint8_t id,
                          uint8_t *out_tx,

--- a/src/loader.c
+++ b/src/loader.c
@@ -8,6 +8,11 @@
 #include "overmap_car_sprite.h"
 #include "dialog.h"
 #include "dialog_data.h"
+#include "dialog_arrow_sprite.h"
+#include "dialog_border_tiles.h"
+#include "npc_drifter_portrait.h"
+#include "npc_mechanic_portrait.h"
+#include "npc_trader_portrait.h"
 
 extern const uint8_t player_tile_data[];
 extern const uint8_t player_tile_data_count;
@@ -20,6 +25,10 @@ BANKREF_EXTERN(bullet_tile_data)
 extern const uint8_t turret_tile_data[];
 extern const uint8_t turret_tile_data_count;
 BANKREF_EXTERN(turret_tile_data)
+
+extern const uint8_t overmap_tile_data[];
+extern const uint8_t overmap_tile_data_count;
+BANKREF_EXTERN(overmap_tile_data)
 
 BANKREF_EXTERN(track_checkpoints)
 BANKREF_EXTERN(track2_checkpoints)
@@ -230,6 +239,10 @@ static uint8_t loader_vram_bitmap[32];  /* zero-initialized (static storage) */
  * 0xFF = not yet allocated. Updated by Increment 2 (loader_load_asset). */
 static uint8_t loader_asset_slot[TILE_ASSET_COUNT];
 
+/* Bank-per-asset table — populated at runtime by loader_init_allocator().
+ * BANK(sym) is a runtime expression in SDCC, not a constant initializer. */
+static uint8_t loader_asset_bank_tbl[TILE_ASSET_COUNT];
+
 #ifndef __SDCC
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank) {
     loader_active_map_ptr = map;
@@ -246,6 +259,20 @@ void loader_init_allocator(void) NONBANKED {
     uint8_t i;
     for (i = 0u; i < 32u; i++) loader_vram_bitmap[i] = 0u;
     for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) loader_asset_slot[i] = 0xFFu;
+    /* Populate bank table at runtime — BANK(sym) is not a constant expression
+     * in SDCC, so this cannot be done as a static initializer. */
+    loader_asset_bank_tbl[TILE_ASSET_PLAYER]       = BANK(player_tile_data);
+    loader_asset_bank_tbl[TILE_ASSET_BULLET]        = BANK(bullet_tile_data);
+    loader_asset_bank_tbl[TILE_ASSET_TURRET]        = BANK(turret_tile_data);
+    loader_asset_bank_tbl[TILE_ASSET_OVERMAP_CAR]   = BANK(overmap_car_tile_data);
+    loader_asset_bank_tbl[TILE_ASSET_DIALOG_ARROW]  = BANK(dialog_arrow_tile_data);
+    loader_asset_bank_tbl[TILE_ASSET_TRACK]         = BANK(track_tile_data);
+    loader_asset_bank_tbl[TILE_ASSET_OVERMAP_BG]    = BANK(overmap_tile_data);
+    loader_asset_bank_tbl[TILE_ASSET_HUD_FONT]      = 0u; /* self-managed, fixed page */
+    loader_asset_bank_tbl[TILE_ASSET_NPC_DRIFTER]   = BANK(npc_drifter_portrait);
+    loader_asset_bank_tbl[TILE_ASSET_NPC_MECHANIC]  = BANK(npc_mechanic_portrait);
+    loader_asset_bank_tbl[TILE_ASSET_NPC_TRADER]    = BANK(npc_trader_portrait);
+    loader_asset_bank_tbl[TILE_ASSET_DIALOG_BORDER] = BANK(dialog_border_tiles);
 }
 
 uint8_t loader_alloc_slots(uint8_t region_start, uint8_t region_end, uint8_t count) NONBANKED {
@@ -289,6 +316,35 @@ void loader_free_slots(uint8_t first_slot, uint8_t count) NONBANKED {
 uint8_t loader_get_asset_slot(tile_asset_t asset) NONBANKED {
     if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) return 0xFFu;
     return loader_asset_slot[(uint8_t)asset];
+}
+
+/* ---- ROM-resident registry and bank table ---- */
+
+/* ROM-resident registry — parallel to loader_asset_bank_tbl[].
+ * data/count_ptr are NULL for self-managed assets (TILE_ASSET_HUD_FONT). */
+static const tile_registry_entry_t loader_registry_tbl[TILE_ASSET_COUNT] = {
+    { player_tile_data,       &player_tile_data_count,       1u }, /* PLAYER        — sprite */
+    { bullet_tile_data,       &bullet_tile_data_count,       1u }, /* BULLET        — sprite */
+    { turret_tile_data,       &turret_tile_data_count,       1u }, /* TURRET        — sprite */
+    { overmap_car_tile_data,  &overmap_car_tile_data_count,  1u }, /* OVERMAP_CAR   — sprite */
+    { dialog_arrow_tile_data, &dialog_arrow_tile_data_count, 1u }, /* DIALOG_ARROW  — sprite */
+    { track_tile_data,        &track_tile_data_count,        0u }, /* TRACK         — BG     */
+    { overmap_tile_data,      &overmap_tile_data_count,      0u }, /* OVERMAP_BG    — BG     */
+    { 0,                      0,                             0u }, /* HUD_FONT      — self-managed */
+    { npc_drifter_portrait,   &npc_drifter_portrait_count,   0u }, /* NPC_DRIFTER   — BG     */
+    { npc_mechanic_portrait,  &npc_mechanic_portrait_count,  0u }, /* NPC_MECHANIC  — BG     */
+    { npc_trader_portrait,    &npc_trader_portrait_count,    0u }, /* NPC_TRADER    — BG     */
+    { dialog_border_tiles,    &dialog_border_tiles_count,    0u }, /* DIALOG_BORDER — BG     */
+};
+
+const tile_registry_entry_t *loader_get_registry(tile_asset_t asset) NONBANKED {
+    if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) return 0;
+    return &loader_registry_tbl[(uint8_t)asset];
+}
+
+uint8_t loader_get_asset_bank(tile_asset_t asset) NONBANKED {
+    if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) return 0u;
+    return loader_asset_bank_tbl[(uint8_t)asset];
 }
 
 void load_npc_positions(uint8_t id,

--- a/src/loader.h
+++ b/src/loader.h
@@ -92,7 +92,7 @@ typedef struct {
 
 /* VRAM slot bitmap allocator.
  * Slots 0-63 = sprite region. Slots 64-254 = BG region. Slot 255 = reserved failure sentinel.
- * Returns first slot of a free run of `count` consecutive slots in [region_start, region_end-1],
+ * Returns first slot of a free run of `count` consecutive slots in [region_start, region_end] (inclusive),
  * or 0xFF on failure (including if region_end > 254). */
 uint8_t loader_alloc_slots(uint8_t region_start, uint8_t region_end, uint8_t count) NONBANKED;
 

--- a/src/loader.h
+++ b/src/loader.h
@@ -65,9 +65,59 @@ void    loader_map_fill_col(uint8_t tx, uint8_t w, uint8_t h, uint8_t ty_start, 
  * Call before dialog_start() and after dialog_advance() returns 1. */
 void loader_dialog_cache_node(uint8_t npc_id, uint8_t node_idx) NONBANKED;
 
+/* Tile asset registry — one entry per loaded asset.
+ * TILE_ASSET_HUD_FONT is self-managed by hud.c; its registry entry is a NULL sentinel. */
+typedef enum {
+    TILE_ASSET_PLAYER         = 0,
+    TILE_ASSET_BULLET         = 1,
+    TILE_ASSET_TURRET         = 2,
+    TILE_ASSET_OVERMAP_CAR    = 3,
+    TILE_ASSET_DIALOG_ARROW   = 4,
+    TILE_ASSET_TRACK          = 5,
+    TILE_ASSET_OVERMAP_BG     = 6,
+    TILE_ASSET_HUD_FONT       = 7,   /* self-managed by hud.c — NULL registry entry */
+    TILE_ASSET_NPC_DRIFTER    = 8,
+    TILE_ASSET_NPC_MECHANIC   = 9,
+    TILE_ASSET_NPC_TRADER     = 10,
+    TILE_ASSET_DIALOG_BORDER  = 11,
+    TILE_ASSET_COUNT          = 12
+} tile_asset_t;
+
+/* Registry struct — ROM-resident; bank stored separately in loader_asset_bank[]. */
+typedef struct {
+    const uint8_t *data;       /* ROM pointer to tile data; NULL for self-managed assets */
+    const uint8_t *count_ptr;  /* pointer to X_tile_data_count variable; NULL if self-managed */
+    uint8_t        is_sprite;  /* 1 = sprite region (slots 0-63), 0 = BG region (slots 64-254) */
+} tile_registry_entry_t;
+
+/* VRAM slot bitmap allocator.
+ * Slots 0-63 = sprite region. Slots 64-254 = BG region. Slot 255 = reserved failure sentinel.
+ * Returns first slot of a free run of `count` consecutive slots in [region_start, region_end-1],
+ * or 0xFF on failure (including if region_end > 254). */
+uint8_t loader_alloc_slots(uint8_t region_start, uint8_t region_end, uint8_t count) NONBANKED;
+
+/* Clears `count` consecutive bitmap bits starting at `first_slot`. */
+void    loader_free_slots(uint8_t first_slot, uint8_t count) NONBANKED;
+
+/* Returns the first VRAM slot allocated to `asset`, or 0xFF if not yet allocated. */
+uint8_t loader_get_asset_slot(tile_asset_t asset) NONBANKED;
+
+/* Initializes the VRAM bitmap (all free) and asset slot table (all 0xFF).
+ * Call once during STATE_INIT. */
+void    loader_init_allocator(void) NONBANKED;
+
+/* Returns a pointer to the ROM-resident registry entry for `asset`.
+ * Returns NULL if asset >= TILE_ASSET_COUNT. */
+const tile_registry_entry_t *loader_get_registry(tile_asset_t asset) NONBANKED;
+
+/* Returns the bank number for `asset` from the ROM-resident bank table. */
+uint8_t loader_get_asset_bank(tile_asset_t asset) NONBANKED;
+
 #ifndef __SDCC
 /* Test-only seam: inject a synthetic active map without a hardware bank switch. */
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank);
+/* Test-only seam: reset bitmap and slot table to initial state. Call in setUp(). */
+void loader_reset_bitmap_for_test(void);
 #endif
 
 #endif /* LOADER_H */

--- a/src/npc_drifter_portrait.h
+++ b/src/npc_drifter_portrait.h
@@ -4,4 +4,5 @@
 #include "banking.h"
 BANKREF_EXTERN(npc_drifter_portrait)
 extern const uint8_t npc_drifter_portrait[];
+extern const uint8_t npc_drifter_portrait_count;
 #endif

--- a/src/npc_mechanic_portrait.h
+++ b/src/npc_mechanic_portrait.h
@@ -4,4 +4,5 @@
 #include "banking.h"
 BANKREF_EXTERN(npc_mechanic_portrait)
 extern const uint8_t npc_mechanic_portrait[];
+extern const uint8_t npc_mechanic_portrait_count;
 #endif

--- a/src/npc_trader_portrait.h
+++ b/src/npc_trader_portrait.h
@@ -4,4 +4,5 @@
 #include "banking.h"
 BANKREF_EXTERN(npc_trader_portrait)
 extern const uint8_t npc_trader_portrait[];
+extern const uint8_t npc_trader_portrait_count;
 #endif

--- a/tests/test_loader.c
+++ b/tests/test_loader.c
@@ -3,7 +3,9 @@
 #include "loader.h"
 #include "track.h"
 
-void setUp(void) {}
+void setUp(void) {
+    loader_reset_bitmap_for_test();
+}
 void tearDown(void) {}
 
 /* Host tests verify that loader functions compile, link, and run without
@@ -76,6 +78,69 @@ void test_load_bkg_row_writes_to_mock_vram(void) {
     TEST_ASSERT_EQUAL_UINT8(7u, mock_vram[1u * 32u + 4u]);
 }
 
+/* ---- Allocator tests ---- */
+
+void test_alloc_returns_region_start_when_empty(void) {
+    /* Bitmap starts zeroed (static storage). Alloc 1 slot in sprite region 40-47. */
+    uint8_t slot = loader_alloc_slots(40u, 47u, 1u);
+    TEST_ASSERT_EQUAL_UINT8(40u, slot);
+}
+
+void test_alloc_sets_bitmap_bits(void) {
+    /* After allocating slot 50, a second alloc in [50,50] must fail (bit occupied). */
+    loader_alloc_slots(50u, 50u, 1u);
+    uint8_t slot = loader_alloc_slots(50u, 50u, 1u);
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, slot);
+}
+
+void test_alloc_consecutive_runs_do_not_overlap(void) {
+    /* Two allocs of 4 slots each in region [48,55] must not overlap. */
+    uint8_t a = loader_alloc_slots(48u, 55u, 4u);
+    uint8_t b = loader_alloc_slots(48u, 55u, 4u);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, a);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, b);
+    /* b must start at or after a + 4 */
+    TEST_ASSERT_TRUE(b >= a + 4u);
+}
+
+void test_alloc_past_region_end_returns_sentinel(void) {
+    /* Request 8 slots in region [60,63] (only 4 slots available). */
+    uint8_t slot = loader_alloc_slots(60u, 63u, 8u);
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, slot);
+}
+
+void test_alloc_exhaustion_returns_sentinel(void) {
+    /* Fill region [56,59] (4 slots) with two 2-slot allocs, then a third must fail. */
+    loader_alloc_slots(56u, 59u, 2u);
+    loader_alloc_slots(56u, 59u, 2u);
+    uint8_t slot = loader_alloc_slots(56u, 59u, 1u);
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, slot);
+}
+
+void test_free_clears_bits_allowing_realloc(void) {
+    uint8_t slot = loader_alloc_slots(32u, 39u, 4u);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, slot);
+    loader_free_slots(slot, 4u);
+    /* After free, same region must be available again. */
+    uint8_t slot2 = loader_alloc_slots(32u, 39u, 4u);
+    TEST_ASSERT_EQUAL_UINT8(slot, slot2);
+}
+
+void test_alloc_region_boundary_enforced(void) {
+    /* region_end > 254 must return 0xFF (slot 255 is reserved sentinel). */
+    uint8_t slot = loader_alloc_slots(253u, 255u, 2u);
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, slot);
+}
+
+void test_get_asset_slot_returns_sentinel_initially(void) {
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, loader_get_asset_slot(TILE_ASSET_PLAYER));
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, loader_get_asset_slot(TILE_ASSET_DIALOG_BORDER));
+}
+
+void test_tile_asset_count_is_correct(void) {
+    TEST_ASSERT_EQUAL_UINT8(12u, (uint8_t)TILE_ASSET_COUNT);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_load_player_tiles_is_callable);
@@ -88,5 +153,14 @@ int main(void) {
     RUN_TEST(test_load_npc_positions_id2_returns_count);
     RUN_TEST(test_load_bkg_row_increments_mock_count);
     RUN_TEST(test_load_bkg_row_writes_to_mock_vram);
+    RUN_TEST(test_alloc_returns_region_start_when_empty);
+    RUN_TEST(test_alloc_sets_bitmap_bits);
+    RUN_TEST(test_alloc_consecutive_runs_do_not_overlap);
+    RUN_TEST(test_alloc_past_region_end_returns_sentinel);
+    RUN_TEST(test_alloc_exhaustion_returns_sentinel);
+    RUN_TEST(test_free_clears_bits_allowing_realloc);
+    RUN_TEST(test_alloc_region_boundary_enforced);
+    RUN_TEST(test_get_asset_slot_returns_sentinel_initially);
+    RUN_TEST(test_tile_asset_count_is_correct);
     return UNITY_END();
 }

--- a/tests/test_loader.c
+++ b/tests/test_loader.c
@@ -141,6 +141,34 @@ void test_tile_asset_count_is_correct(void) {
     TEST_ASSERT_EQUAL_UINT8(12u, (uint8_t)TILE_ASSET_COUNT);
 }
 
+/* ---- Registry tests ---- */
+
+void test_registry_player_is_sprite(void) {
+    const tile_registry_entry_t *e = loader_get_registry(TILE_ASSET_PLAYER);
+    TEST_ASSERT_NOT_NULL(e);
+    TEST_ASSERT_EQUAL_UINT8(1u, e->is_sprite);
+    TEST_ASSERT_NOT_NULL(e->data);
+    TEST_ASSERT_NOT_NULL(e->count_ptr);
+}
+
+void test_registry_track_is_bg(void) {
+    const tile_registry_entry_t *e = loader_get_registry(TILE_ASSET_TRACK);
+    TEST_ASSERT_NOT_NULL(e);
+    TEST_ASSERT_EQUAL_UINT8(0u, e->is_sprite);
+}
+
+void test_registry_hud_font_is_null_sentinel(void) {
+    const tile_registry_entry_t *e = loader_get_registry(TILE_ASSET_HUD_FONT);
+    TEST_ASSERT_NOT_NULL(e);       /* entry exists */
+    TEST_ASSERT_NULL(e->data);     /* but data is NULL (self-managed) */
+    TEST_ASSERT_NULL(e->count_ptr);
+}
+
+void test_registry_out_of_bounds_returns_null(void) {
+    const tile_registry_entry_t *e = loader_get_registry((tile_asset_t)TILE_ASSET_COUNT);
+    TEST_ASSERT_NULL(e);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_load_player_tiles_is_callable);
@@ -162,5 +190,9 @@ int main(void) {
     RUN_TEST(test_alloc_region_boundary_enforced);
     RUN_TEST(test_get_asset_slot_returns_sentinel_initially);
     RUN_TEST(test_tile_asset_count_is_correct);
+    RUN_TEST(test_registry_player_is_sprite);
+    RUN_TEST(test_registry_track_is_bg);
+    RUN_TEST(test_registry_hud_font_is_null_sentinel);
+    RUN_TEST(test_registry_out_of_bounds_returns_null);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Adds `tile_asset_t` enum (12 entries) to `loader.h` for all managed sprite/BG assets
- Implements 32-byte WRAM bitmap allocator (`loader_alloc_slots`, `loader_free_slots`) with first-fit algorithm; WRAM cost 47B total (within 50B budget)
- Adds ROM-resident `tile_registry_entry_t` table mapping each asset to its data pointer, count pointer, and sprite/BG flag; asset bank lookup uses inline `BANK(sym)` switch (zero WRAM cost)
- 23 host-side unit tests (TDD); no VRAM writes in this increment

## Test Plan
- [x] `make test` passes (23 tests, 0 failures)
- [x] Emulicious smoketest confirmed by user
- [x] bank-post-build gates passed (ROM_0: 88%, ROM_1: 98%, ROM_2: 85% — all WARN, no FAIL)
- [x] gb-memory-validator: WRAM 12%, VRAM 5%, OAM 77% — all PASS

Closes #292