### PR TITLE
fix: align MAX_NPCS to 8 and add tmx_to_c truncation warning (#316 R5/R6)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -351,7 +351,8 @@
       "Bash(go build:*)",
       "Bash(xargs -I{} basename {})",
       "Bash(sdcc --version)",
-      "Bash(/home/mathdaman/gbdk/bin/sdasgb -l font.o)"
+      "Bash(/home/mathdaman/gbdk/bin/sdasgb -l font.o)",
+      "Bash(/home/mathdaman/gbdk/bin/romusage:*)"
     ]
   },
   "hooks": {

--- a/assets/dialog/npcs.json
+++ b/assets/dialog/npcs.json
@@ -161,6 +161,34 @@
           ]
         }
       ]
+    },
+    {
+      "id": 6,
+      "name": "PLACEHOLDER6",
+      "nodes": [
+        {
+          "idx": 0,
+          "text": "...",
+          "choices": [],
+          "next": [
+            "END"
+          ]
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "name": "PLACEHOLDER7",
+      "nodes": [
+        {
+          "idx": 0,
+          "text": "...",
+          "choices": [],
+          "next": [
+            "END"
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/config.h
+++ b/src/config.h
@@ -4,7 +4,7 @@
 /* Entity capacity constants — all entity pools MUST use SoA (parallel arrays),
  * not AoS (struct arrays). See CLAUDE.md "Entity management" for rationale. */
 
-#define MAX_NPCS     6
+#define MAX_NPCS     8
 /* OAM budget: player=4, dialog_arrow=1 (fixed), projectiles≤8, turrets≤8; hardware cap=40 */
 #define MAX_SPRITES  28
 

--- a/src/dialog_data.c
+++ b/src/dialog_data.c
@@ -77,6 +77,22 @@ static const DialogNode placeholder5_nodes[] = {
     /* 0 */ { n5_0, 0, {NULL,   NULL,   NULL}, {DIALOG_END, DIALOG_END, DIALOG_END} },
 };
 
+/* --- NPC 6: PLACEHOLDER6 --- */
+static const char n6_0[] = "...";
+static const char npc_name_placeholder6[] = "PLACEHOLDER6";
+
+static const DialogNode placeholder6_nodes[] = {
+    /* 0 */ { n6_0, 0, {NULL,   NULL,   NULL}, {DIALOG_END, DIALOG_END, DIALOG_END} },
+};
+
+/* --- NPC 7: PLACEHOLDER7 --- */
+static const char n7_0[] = "...";
+static const char npc_name_placeholder7[] = "PLACEHOLDER7";
+
+static const DialogNode placeholder7_nodes[] = {
+    /* 0 */ { n7_0, 0, {NULL,   NULL,   NULL}, {DIALOG_END, DIALOG_END, DIALOG_END} },
+};
+
 /* --- NPC dialog table (indexed by npc_id) --- */
 BANKREF(npc_dialogs)
 const NpcDialog npc_dialogs[] = {
@@ -86,4 +102,6 @@ const NpcDialog npc_dialogs[] = {
     { placeholder3_nodes, 1, npc_name_placeholder3 }, /* NPC 3: PLACEHOLDER3 */
     { placeholder4_nodes, 1, npc_name_placeholder4 }, /* NPC 4: PLACEHOLDER4 */
     { placeholder5_nodes, 1, npc_name_placeholder5 }, /* NPC 5: PLACEHOLDER5 */
+    { placeholder6_nodes, 1, npc_name_placeholder6 }, /* NPC 6: PLACEHOLDER6 */
+    { placeholder7_nodes, 1, npc_name_placeholder7 }, /* NPC 7: PLACEHOLDER7 */
 };

--- a/tests/test_soa_convention.c
+++ b/tests/test_soa_convention.c
@@ -5,8 +5,8 @@ void setUp(void) {}
 void tearDown(void) {}
 
 void test_max_npcs_sane(void) {
-    /* At least 6 NPCs required by current design; see src/config.h */
-    TEST_ASSERT_GREATER_OR_EQUAL(6, MAX_NPCS);
+    /* At least 8 NPCs required — matches tmx_to_c.py cap; see src/config.h */
+    TEST_ASSERT_GREATER_OR_EQUAL(8, MAX_NPCS);
 }
 
 void test_max_sprites_sane(void) {

--- a/tests/test_tmx_to_c.py
+++ b/tests/test_tmx_to_c.py
@@ -492,6 +492,46 @@ class TestEnemiesLayer(unittest.TestCase):
         self.assertNotIn('turret_ty', result)
         self.assertNotIn('turret_count', result)
 
+    def test_npc_truncation_warning_printed_to_stderr(self):
+        """When more than MAX_NPCS NPCs are in the TMX, a warning is printed to stderr."""
+        import io, contextlib
+        # Build a minimal TMX with MAX_NPCS + 1 enemy objects
+        npc_objects = ""
+        for i in range(9):  # 9 > MAX_NPCS (8)
+            npc_objects += f'<object id="{i+1}" name="car" x="{i*16}" y="16" width="8" height="8"/>\n'
+        tmx = f'''<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.10" orientation="orthogonal" renderorder="right-down"
+     width="10" height="10" tilewidth="8" tileheight="8">
+ <tileset firstgid="1" source="tileset.tsx"/>
+ <layer id="1" name="track" width="10" height="10">
+  <data encoding="csv">{",".join(["1"]*100)}</data>
+ </layer>
+ <objectgroup id="2" name="start">
+  <object id="100" x="0" y="0" width="8" height="8"/>
+ </objectgroup>
+ <objectgroup id="3" name="finish">
+  <object id="101" x="0" y="8" width="80" height="8"/>
+ </objectgroup>
+ <objectgroup id="4" name="enemies">
+  {npc_objects}
+ </objectgroup>
+</map>'''
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.tmx', delete=False) as f:
+            f.write(tmx)
+            tmx_path = f.name
+        out_path = tmx_path.replace('.tmx', '.c')
+        try:
+            stderr_capture = io.StringIO()
+            with contextlib.redirect_stderr(stderr_capture):
+                conv.tmx_to_c(tmx_path, out_path)
+            warning_output = stderr_capture.getvalue()
+            self.assertIn("WARNING", warning_output)
+            self.assertIn("MAX_NPCS", warning_output)
+        finally:
+            os.unlink(tmx_path)
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+
 
 class TestEmitHeader(unittest.TestCase):
 

--- a/tools/tmx_to_c.py
+++ b/tools/tmx_to_c.py
@@ -93,6 +93,11 @@ def parse_npc_objects(root):
             ty = int(py) // 8
             npcs.append((tx, ty, type_val, dir_val))
             if len(npcs) >= MAX_NPCS:
+                print(
+                    f"WARNING: tmx_to_c: NPC count hit cap (MAX_NPCS={MAX_NPCS}), "
+                    f"truncating remaining NPCs.",
+                    file=sys.stderr,
+                )
                 break
         break  # only process first 'enemies' layer
     return npcs
@@ -279,13 +284,13 @@ def tmx_to_c(tmx_path, out_path, prefix='track', emit_powerup_header=None):
         f.write(f"\nBANKREF({prefix}_npc_count)\n")
         f.write(f"const uint8_t {prefix}_npc_count = {npc_count}u;\n\n")
         f.write(f"BANKREF({prefix}_npc_tx)\n")
-        f.write(f"const uint8_t {prefix}_npc_tx[8] = {{ {fmt_arr(npc_tx)} }};\n\n")
+        f.write(f"const uint8_t {prefix}_npc_tx[{MAX_NPCS}] = {{ {fmt_arr(npc_tx)} }};\n\n")
         f.write(f"BANKREF({prefix}_npc_ty)\n")
-        f.write(f"const uint8_t {prefix}_npc_ty[8] = {{ {fmt_arr(npc_ty)} }};\n\n")
+        f.write(f"const uint8_t {prefix}_npc_ty[{MAX_NPCS}] = {{ {fmt_arr(npc_ty)} }};\n\n")
         f.write(f"BANKREF({prefix}_npc_type)\n")
-        f.write(f"const uint8_t {prefix}_npc_type[8] = {{ {fmt_arr(npc_type)} }};\n\n")
+        f.write(f"const uint8_t {prefix}_npc_type[{MAX_NPCS}] = {{ {fmt_arr(npc_type)} }};\n\n")
         f.write(f"BANKREF({prefix}_npc_dir)\n")
-        f.write(f"const uint8_t {prefix}_npc_dir[8] = {{ {fmt_arr(npc_dir)} }};\n")
+        f.write(f"const uint8_t {prefix}_npc_dir[{MAX_NPCS}] = {{ {fmt_arr(npc_dir)} }};\n")
         f.write(f"\nBANKREF({prefix}_powerup_count)\n")
         f.write(f"const uint8_t {prefix}_powerup_count = {powerup_count}u;\n\n")
         f.write(f"BANKREF({prefix}_powerup_tx)\n")


### PR DESCRIPTION
## Summary
- Bump `MAX_NPCS` from 6 → 8 in `src/config.h` to match the actual cap enforced by `tools/tmx_to_c.py`
- Replace hardcoded `[8]` array-size literals in `tmx_to_c.py` output with `[{MAX_NPCS}]`
- Add stderr warning when NPC count hits cap during map conversion
- Extend `assets/dialog/npcs.json` and regenerate `src/dialog_data.c` with placeholder stubs for NPCs 6–7

## Test Plan
- [x] `make test` passes (all C tests green)
- [x] `make test-tools` new test `test_npc_truncation_warning_printed_to_stderr` passes; 5 pre-existing failures unchanged
- [x] Emulicious smoketest confirmed by user — track 2 loads and scrolls without regression
- [x] bank-post-build gates passed
- [x] gb-memory-validator: no FAIL budgets

Closes part of #316 (R5 and R6 only — manual tileset/map work R1–R4 handled separately)