### PR TITLE
feat(loader): Increment 2 — wire allocator to VRAM writes

### DIFF
--- a/src/loader.c
+++ b/src/loader.c
@@ -293,11 +293,11 @@ static void loader_do_load_one(tile_asset_t asset) NONBANKED {
     SWITCH_ROM(saved);
 }
 
-void loader_load_state(const tile_asset_t *assets, uint8_t count) NONBANKED {
+void loader_load_state(const uint8_t *assets, uint8_t count) NONBANKED {
     uint8_t i;
     if (loader_state_active) { disable_interrupts(); while (1) {} } /* assert: double-load */
     for (i = 0u; i < count; i++) {
-        loader_do_load_one(assets[i]);
+        loader_do_load_one((tile_asset_t)assets[i]);
     }
     loader_state_active = 1u;
 }
@@ -339,29 +339,31 @@ void loader_load_asset(tile_asset_t asset) NONBANKED {
 }
 
 /* ---- State manifests — ROM-resident, zero WRAM cost ---- */
+/* uint8_t arrays (not tile_asset_t) so each element is 1 byte;
+ * SDCC would otherwise emit 2-byte enum elements on SM83. */
 
-const tile_asset_t k_playing_assets[] = {
+const uint8_t k_playing_assets[] = {
     TILE_ASSET_PLAYER,
     TILE_ASSET_BULLET,
     TILE_ASSET_TURRET,
     TILE_ASSET_TRACK,
 };
-const uint8_t k_playing_assets_count = 4u;
+const uint8_t k_playing_assets_count = (uint8_t)(sizeof(k_playing_assets) / sizeof(k_playing_assets[0]));
 
-const tile_asset_t k_overmap_assets[] = {
+const uint8_t k_overmap_assets[] = {
     TILE_ASSET_OVERMAP_CAR,
     TILE_ASSET_OVERMAP_BG,
 };
-const uint8_t k_overmap_assets_count = 2u;
+const uint8_t k_overmap_assets_count = (uint8_t)(sizeof(k_overmap_assets) / sizeof(k_overmap_assets[0]));
 
-const tile_asset_t k_hub_assets[] = {
+const uint8_t k_hub_assets[] = {
     TILE_ASSET_DIALOG_ARROW,
     TILE_ASSET_NPC_DRIFTER,
     TILE_ASSET_NPC_MECHANIC,
     TILE_ASSET_NPC_TRADER,
     TILE_ASSET_DIALOG_BORDER,
 };
-const uint8_t k_hub_assets_count = 5u;
+const uint8_t k_hub_assets_count = (uint8_t)(sizeof(k_hub_assets) / sizeof(k_hub_assets[0]));
 
 #ifndef __SDCC
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank) {

--- a/src/loader.c
+++ b/src/loader.c
@@ -55,6 +55,9 @@ static const uint8_t  *loader_active_map_ptr = track_map + 2u;
  * Used by loader_get_registry() to select the per-track BG tile registry entry. */
 static uint8_t loader_active_track = 0u;
 
+/* 1 when a state's assets are loaded via loader_load_state(); 0 otherwise. */
+static uint8_t loader_state_active = 0u;
+
 /* track3 scalars — extern'd here for use in load_track_scalars() */
 extern const int16_t track3_start_x;
 extern const int16_t track3_start_y;
@@ -255,6 +258,66 @@ void loader_set_track(uint8_t track_id) NONBANKED {
     loader_active_track = track_id;
 }
 
+/* Internal helper — allocates VRAM slots and writes tile data for one asset.
+ * Asserts (halts) if the registry entry has NULL data (self-managed asset) or
+ * if the VRAM region is exhausted. Does NOT check for double-load; callers enforce that. */
+static void loader_do_load_one(tile_asset_t asset) {
+    uint8_t saved;
+    uint8_t slot;
+    uint8_t tile_count;
+    uint8_t region_start;
+    uint8_t region_end;
+    const tile_registry_entry_t *entry;
+    entry = loader_get_registry(asset);
+    if (!entry || !entry->data) { disable_interrupts(); while (1) {} } /* assert: self-managed asset */
+    tile_count = *entry->count_ptr;
+    if (entry->is_sprite) {
+        region_start = 0u;
+        region_end   = 63u;
+    } else {
+        region_start = 64u;
+        region_end   = 254u;
+    }
+    slot = loader_alloc_slots(region_start, region_end, tile_count);
+    if (slot == 0xFFu) { disable_interrupts(); while (1) {} } /* assert: VRAM region exhausted */
+    loader_asset_slot[(uint8_t)asset] = slot;
+    saved = CURRENT_BANK;
+    SWITCH_ROM(loader_get_asset_bank(asset));
+    if (entry->is_sprite) {
+        set_sprite_data(slot, tile_count, entry->data);
+    } else {
+        set_bkg_data(slot, tile_count, entry->data);
+    }
+    SWITCH_ROM(saved);
+}
+
+void loader_load_state(const tile_asset_t *assets, uint8_t count) NONBANKED {
+    uint8_t i;
+    if (loader_state_active) { disable_interrupts(); while (1) {} } /* assert: double-load */
+    for (i = 0u; i < count; i++) {
+        loader_do_load_one(assets[i]);
+    }
+    loader_state_active = 1u;
+}
+
+void loader_unload_state(void) NONBANKED {
+    uint8_t i;
+    uint8_t slot;
+    uint8_t tile_count;
+    const tile_registry_entry_t *entry;
+    if (!loader_state_active) { disable_interrupts(); while (1) {} } /* assert: unload with no state loaded */
+    for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) {
+        slot = loader_asset_slot[i];
+        if (slot == 0xFFu) continue;
+        entry = loader_get_registry((tile_asset_t)i);
+        if (!entry || !entry->count_ptr) continue; /* self-managed — skip */
+        tile_count = *entry->count_ptr;
+        loader_free_slots(slot, tile_count);
+        loader_asset_slot[i] = 0xFFu;
+    }
+    loader_state_active = 0u;
+}
+
 #ifndef __SDCC
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank) {
     loader_active_map_ptr = map;
@@ -265,6 +328,7 @@ void loader_reset_bitmap_for_test(void) {
     for (i = 0u; i < 32u; i++) loader_vram_bitmap[i] = 0u;
     for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) loader_asset_slot[i] = 0xFFu;
     loader_active_track = 0u;
+    loader_state_active = 0u;
 }
 #endif
 
@@ -273,6 +337,7 @@ void loader_init_allocator(void) NONBANKED {
     for (i = 0u; i < 32u; i++) loader_vram_bitmap[i] = 0u;
     for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) loader_asset_slot[i] = 0xFFu;
     loader_active_track = 0u;
+    loader_state_active = 0u;
 }
 
 uint8_t loader_alloc_slots(uint8_t region_start, uint8_t region_end, uint8_t count) NONBANKED {

--- a/src/loader.c
+++ b/src/loader.c
@@ -51,6 +51,10 @@ extern uint8_t active_map_h;
 static uint8_t         loader_active_data_bank = 1u;  /* default: track 0/1 bank */
 static const uint8_t  *loader_active_map_ptr = track_map + 2u;
 
+/* Active track index (0-2) — set by loader_set_track().
+ * Used by loader_get_registry() to select the per-track BG tile registry entry. */
+static uint8_t loader_active_track = 0u;
+
 /* track3 scalars — extern'd here for use in load_track_scalars() */
 extern const int16_t track3_start_x;
 extern const int16_t track3_start_y;
@@ -240,6 +244,11 @@ static uint8_t loader_vram_bitmap[32];  /* zero-initialized (static storage) */
 static uint8_t loader_asset_slot[TILE_ASSET_COUNT];
 
 
+void loader_set_track(uint8_t track_id) NONBANKED {
+    if (track_id > 2u) { while (1) {} } /* assert: invalid track id */
+    loader_active_track = track_id;
+}
+
 #ifndef __SDCC
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank) {
     loader_active_map_ptr = map;
@@ -249,6 +258,7 @@ void loader_reset_bitmap_for_test(void) {
     uint8_t i;
     for (i = 0u; i < 32u; i++) loader_vram_bitmap[i] = 0u;
     for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) loader_asset_slot[i] = 0xFFu;
+    loader_active_track = 0u;
 }
 #endif
 
@@ -256,6 +266,7 @@ void loader_init_allocator(void) NONBANKED {
     uint8_t i;
     for (i = 0u; i < 32u; i++) loader_vram_bitmap[i] = 0u;
     for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) loader_asset_slot[i] = 0xFFu;
+    loader_active_track = 0u;
 }
 
 uint8_t loader_alloc_slots(uint8_t region_start, uint8_t region_end, uint8_t count) NONBANKED {
@@ -322,8 +333,19 @@ static const tile_registry_entry_t loader_registry_tbl[TILE_ASSET_COUNT] = {
     { dialog_border_tiles,    &dialog_border_tiles_count,    0u }, /* DIALOG_BORDER — BG     */
 };
 
+/* Per-track BG tile registry — indexed by loader_active_track (0-2).
+ * All three currently point to track_tile_data (tracks 1 and 2 are placeholders).
+ * Replace entries when per-track tile assets are introduced. */
+static const tile_registry_entry_t loader_track_registry_tbl[3u] = {
+    { track_tile_data, &track_tile_data_count, 0u }, /* track 0 */
+    { track_tile_data, &track_tile_data_count, 0u }, /* track 1 — placeholder */
+    { track_tile_data, &track_tile_data_count, 0u }, /* track 2 — placeholder */
+};
+
 const tile_registry_entry_t *loader_get_registry(tile_asset_t asset) NONBANKED {
     if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) return 0;
+    if ((uint8_t)asset == (uint8_t)TILE_ASSET_TRACK)
+        return &loader_track_registry_tbl[loader_active_track];
     return &loader_registry_tbl[(uint8_t)asset];
 }
 

--- a/src/loader.c
+++ b/src/loader.c
@@ -324,6 +324,20 @@ void loader_unload_state(void) NONBANKED {
     loader_state_active = 0u;
 }
 
+uint8_t loader_get_slot(tile_asset_t asset) NONBANKED {
+    uint8_t slot;
+    if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) { disable_interrupts(); while (1) {} }
+    slot = loader_asset_slot[(uint8_t)asset];
+    if (slot == 0xFFu) { disable_interrupts(); while (1) {} } /* assert: asset not currently loaded */
+    return slot;
+}
+
+void loader_load_asset(tile_asset_t asset) NONBANKED {
+    if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) { disable_interrupts(); while (1) {} }
+    if (loader_asset_slot[(uint8_t)asset] != 0xFFu) { disable_interrupts(); while (1) {} } /* assert: already loaded */
+    loader_do_load_one(asset);
+}
+
 #ifndef __SDCC
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank) {
     loader_active_map_ptr = map;

--- a/src/loader.c
+++ b/src/loader.c
@@ -260,8 +260,9 @@ void loader_set_track(uint8_t track_id) NONBANKED {
 
 /* Internal helper — allocates VRAM slots and writes tile data for one asset.
  * Asserts (halts) if the registry entry has NULL data (self-managed asset) or
- * if the VRAM region is exhausted. Does NOT check for double-load; callers enforce that. */
-static void loader_do_load_one(tile_asset_t asset) {
+ * if the VRAM region is exhausted. Does NOT check for double-load; callers enforce that.
+ * Uses a single SWITCH_ROM pair: reads count_ptr and writes tile data in one bank window. */
+static void loader_do_load_one(tile_asset_t asset) NONBANKED {
     uint8_t saved;
     uint8_t slot;
     uint8_t tile_count;
@@ -270,7 +271,7 @@ static void loader_do_load_one(tile_asset_t asset) {
     const tile_registry_entry_t *entry;
     entry = loader_get_registry(asset);
     if (!entry || !entry->data) { disable_interrupts(); while (1) {} } /* assert: self-managed asset */
-    tile_count = *entry->count_ptr;
+    /* Determine region from is_sprite (bank-0 static table — always safe). */
     if (entry->is_sprite) {
         region_start = 0u;
         region_end   = 63u;
@@ -278,11 +279,12 @@ static void loader_do_load_one(tile_asset_t asset) {
         region_start = 64u;
         region_end   = 254u;
     }
-    slot = loader_alloc_slots(region_start, region_end, tile_count);
-    if (slot == 0xFFu) { disable_interrupts(); while (1) {} } /* assert: VRAM region exhausted */
-    loader_asset_slot[(uint8_t)asset] = slot;
     saved = CURRENT_BANK;
     SWITCH_ROM(loader_get_asset_bank(asset));
+    tile_count = *entry->count_ptr;                      /* count lives in asset's bank */
+    slot = loader_alloc_slots(region_start, region_end, tile_count); /* NONBANKED — safe */
+    if (slot == 0xFFu) { SWITCH_ROM(saved); disable_interrupts(); while (1) {} }
+    loader_asset_slot[(uint8_t)asset] = slot;
     if (entry->is_sprite) {
         set_sprite_data(slot, tile_count, entry->data);
     } else {
@@ -302,16 +304,20 @@ void loader_load_state(const tile_asset_t *assets, uint8_t count) NONBANKED {
 
 void loader_unload_state(void) NONBANKED {
     uint8_t i;
+    uint8_t saved;
     uint8_t slot;
     uint8_t tile_count;
     const tile_registry_entry_t *entry;
     if (!loader_state_active) { disable_interrupts(); while (1) {} } /* assert: unload with no state loaded */
+    saved = CURRENT_BANK;
     for (i = 0u; i < (uint8_t)TILE_ASSET_COUNT; i++) {
         slot = loader_asset_slot[i];
         if (slot == 0xFFu) continue;
         entry = loader_get_registry((tile_asset_t)i);
         if (!entry || !entry->count_ptr) continue; /* self-managed — skip */
-        tile_count = *entry->count_ptr;
+        SWITCH_ROM(loader_get_asset_bank((tile_asset_t)i));
+        tile_count = *entry->count_ptr;              /* count lives in asset's bank */
+        SWITCH_ROM(saved);
         loader_free_slots(slot, tile_count);
         loader_asset_slot[i] = 0xFFu;
     }

--- a/src/loader.c
+++ b/src/loader.c
@@ -73,6 +73,9 @@ void load_track_tiles(void) NONBANKED {
     SWITCH_ROM(saved);
 }
 
+/* DEPRECATED: identical to load_track_tiles() — placeholder until track 2 gets its own tile data.
+ * Referenced as a function pointer in track.c TrackDef table; remove when per-track
+ * tile data is introduced and callers migrate to loader_set_track() + loader_load_state(). */
 void load_track2_tiles(void) NONBANKED {
     uint8_t saved = CURRENT_BANK;
     SWITCH_ROM(BANK(track_tile_data));
@@ -80,6 +83,9 @@ void load_track2_tiles(void) NONBANKED {
     SWITCH_ROM(saved);
 }
 
+/* DEPRECATED: identical to load_track_tiles() — placeholder until track 3 gets its own tile data.
+ * Referenced as a function pointer in track.c TrackDef table; remove when per-track
+ * tile data is introduced and callers migrate to loader_set_track() + loader_load_state(). */
 void load_track3_tiles(void) NONBANKED {
     uint8_t saved = CURRENT_BANK;
     SWITCH_ROM(BANK(track_tile_data));
@@ -245,7 +251,7 @@ static uint8_t loader_asset_slot[TILE_ASSET_COUNT];
 
 
 void loader_set_track(uint8_t track_id) NONBANKED {
-    if (track_id > 2u) { while (1) {} } /* assert: invalid track id */
+    if (track_id > 2u) { disable_interrupts(); while (1) {} } /* assert: invalid track id */
     loader_active_track = track_id;
 }
 
@@ -344,8 +350,11 @@ static const tile_registry_entry_t loader_track_registry_tbl[3u] = {
 
 const tile_registry_entry_t *loader_get_registry(tile_asset_t asset) NONBANKED {
     if ((uint8_t)asset >= (uint8_t)TILE_ASSET_COUNT) return 0;
-    if ((uint8_t)asset == (uint8_t)TILE_ASSET_TRACK)
-        return &loader_track_registry_tbl[loader_active_track];
+    if ((uint8_t)asset == (uint8_t)TILE_ASSET_TRACK) {
+        if (loader_active_track == 1u) return &loader_track_registry_tbl[1];
+        if (loader_active_track == 2u) return &loader_track_registry_tbl[2];
+        return &loader_track_registry_tbl[0];
+    }
     return &loader_registry_tbl[(uint8_t)asset];
 }
 
@@ -356,7 +365,11 @@ uint8_t loader_get_asset_bank(tile_asset_t asset) NONBANKED {
         case TILE_ASSET_TURRET:        return BANK(turret_tile_data);
         case TILE_ASSET_OVERMAP_CAR:   return BANK(overmap_car_tile_data);
         case TILE_ASSET_DIALOG_ARROW:  return BANK(dialog_arrow_tile_data);
-        case TILE_ASSET_TRACK:         return BANK(track_tile_data);
+        case TILE_ASSET_TRACK:
+            /* Mirror loader_track_registry_tbl — update in sync when per-track banks diverge. */
+            if (loader_active_track == 1u) return BANK(track_tile_data); /* track 1 — placeholder */
+            if (loader_active_track == 2u) return BANK(track_tile_data); /* track 2 — placeholder */
+            return BANK(track_tile_data); /* track 0 */
         case TILE_ASSET_OVERMAP_BG:    return BANK(overmap_tile_data);
         case TILE_ASSET_HUD_FONT:      return 0u;
         case TILE_ASSET_NPC_DRIFTER:   return BANK(npc_drifter_portrait);

--- a/src/loader.c
+++ b/src/loader.c
@@ -338,6 +338,31 @@ void loader_load_asset(tile_asset_t asset) NONBANKED {
     loader_do_load_one(asset);
 }
 
+/* ---- State manifests — ROM-resident, zero WRAM cost ---- */
+
+const tile_asset_t k_playing_assets[] = {
+    TILE_ASSET_PLAYER,
+    TILE_ASSET_BULLET,
+    TILE_ASSET_TURRET,
+    TILE_ASSET_TRACK,
+};
+const uint8_t k_playing_assets_count = 4u;
+
+const tile_asset_t k_overmap_assets[] = {
+    TILE_ASSET_OVERMAP_CAR,
+    TILE_ASSET_OVERMAP_BG,
+};
+const uint8_t k_overmap_assets_count = 2u;
+
+const tile_asset_t k_hub_assets[] = {
+    TILE_ASSET_DIALOG_ARROW,
+    TILE_ASSET_NPC_DRIFTER,
+    TILE_ASSET_NPC_MECHANIC,
+    TILE_ASSET_NPC_TRADER,
+    TILE_ASSET_DIALOG_BORDER,
+};
+const uint8_t k_hub_assets_count = 5u;
+
 #ifndef __SDCC
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank) {
     loader_active_map_ptr = map;

--- a/src/loader.h
+++ b/src/loader.h
@@ -113,6 +113,11 @@ const tile_registry_entry_t *loader_get_registry(tile_asset_t asset) NONBANKED;
 /* Returns the bank number for `asset` from the ROM-resident bank table. */
 uint8_t loader_get_asset_bank(tile_asset_t asset) NONBANKED;
 
+/* Sets the active track index (0-2) used by loader_get_registry() for TILE_ASSET_TRACK.
+ * Call before loader_load_state() when entering a track-based state.
+ * Asserts (halts) if track_id > 2. */
+void loader_set_track(uint8_t track_id) NONBANKED;
+
 #ifndef __SDCC
 /* Test-only seam: inject a synthetic active map without a hardware bank switch. */
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank);

--- a/src/loader.h
+++ b/src/loader.h
@@ -118,6 +118,17 @@ uint8_t loader_get_asset_bank(tile_asset_t asset) NONBANKED;
  * Asserts (halts) if track_id > 2. */
 void loader_set_track(uint8_t track_id) NONBANKED;
 
+/* Allocates VRAM slots and writes tile data for each asset in `assets[0..count-1]`.
+ * Assets are allocated from the sprite region (slots 0-63) or BG region (slots 64-254)
+ * based on each asset's is_sprite registry flag.
+ * Asserts (halts) if: called while a state is already loaded; any asset has NULL data
+ * (self-managed); or the VRAM region is exhausted. */
+void loader_load_state(const tile_asset_t *assets, uint8_t count) NONBANKED;
+
+/* Frees all allocated VRAM slots and resets the slot table to 0xFF.
+ * Asserts (halts) if no state is currently loaded. */
+void loader_unload_state(void) NONBANKED;
+
 #ifndef __SDCC
 /* Test-only seam: inject a synthetic active map without a hardware bank switch. */
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank);

--- a/src/loader.h
+++ b/src/loader.h
@@ -129,6 +129,15 @@ void loader_load_state(const tile_asset_t *assets, uint8_t count) NONBANKED;
  * Asserts (halts) if no state is currently loaded. */
 void loader_unload_state(void) NONBANKED;
 
+/* Returns the VRAM slot assigned to `asset`.
+ * Asserts (halts) if the asset is not currently loaded.
+ * Use loader_get_asset_slot() for a non-asserting query (returns 0xFF if not loaded). */
+uint8_t loader_get_slot(tile_asset_t asset) NONBANKED;
+
+/* Allocates and loads a single asset outside a state manifest (e.g. dynamic portrait).
+ * Asserts (halts) if the asset is already loaded, out of range, or self-managed (NULL data). */
+void loader_load_asset(tile_asset_t asset) NONBANKED;
+
 #ifndef __SDCC
 /* Test-only seam: inject a synthetic active map without a hardware bank switch. */
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank);

--- a/src/loader.h
+++ b/src/loader.h
@@ -123,7 +123,7 @@ void loader_set_track(uint8_t track_id) NONBANKED;
  * based on each asset's is_sprite registry flag.
  * Asserts (halts) if: called while a state is already loaded; any asset has NULL data
  * (self-managed); or the VRAM region is exhausted. */
-void loader_load_state(const tile_asset_t *assets, uint8_t count) NONBANKED;
+void loader_load_state(const uint8_t *assets, uint8_t count) NONBANKED;
 
 /* Frees all allocated VRAM slots and resets the slot table to 0xFF.
  * Asserts (halts) if no state is currently loaded. */
@@ -139,15 +139,15 @@ uint8_t loader_get_slot(tile_asset_t asset) NONBANKED;
 void loader_load_asset(tile_asset_t asset) NONBANKED;
 
 /* State manifests — pass to loader_load_state() at state entry.
- * Each array lists the tile_asset_t values to load for that state. */
-extern const tile_asset_t k_playing_assets[];
-extern const uint8_t      k_playing_assets_count;
+ * uint8_t arrays (not tile_asset_t) so each element is 1 byte on SDCC/SM83. */
+extern const uint8_t k_playing_assets[];
+extern const uint8_t k_playing_assets_count;
 
-extern const tile_asset_t k_overmap_assets[];
-extern const uint8_t      k_overmap_assets_count;
+extern const uint8_t k_overmap_assets[];
+extern const uint8_t k_overmap_assets_count;
 
-extern const tile_asset_t k_hub_assets[];
-extern const uint8_t      k_hub_assets_count;
+extern const uint8_t k_hub_assets[];
+extern const uint8_t k_hub_assets_count;
 
 #ifndef __SDCC
 /* Test-only seam: inject a synthetic active map without a hardware bank switch. */

--- a/src/loader.h
+++ b/src/loader.h
@@ -138,6 +138,17 @@ uint8_t loader_get_slot(tile_asset_t asset) NONBANKED;
  * Asserts (halts) if the asset is already loaded, out of range, or self-managed (NULL data). */
 void loader_load_asset(tile_asset_t asset) NONBANKED;
 
+/* State manifests — pass to loader_load_state() at state entry.
+ * Each array lists the tile_asset_t values to load for that state. */
+extern const tile_asset_t k_playing_assets[];
+extern const uint8_t      k_playing_assets_count;
+
+extern const tile_asset_t k_overmap_assets[];
+extern const uint8_t      k_overmap_assets_count;
+
+extern const tile_asset_t k_hub_assets[];
+extern const uint8_t      k_hub_assets_count;
+
 #ifndef __SDCC
 /* Test-only seam: inject a synthetic active map without a hardware bank switch. */
 void loader_test_set_active_map(const uint8_t *map, uint8_t data_bank);

--- a/tests/mocks/gb/gb.h
+++ b/tests/mocks/gb/gb.h
@@ -32,6 +32,10 @@ typedef int16_t  WORD;
 #define DISPLAY_ON  ((void)0)
 #define DISPLAY_OFF ((void)0)
 
+/* Interrupt control — no-ops in host tests */
+static inline void disable_interrupts(void) {}
+static inline void enable_interrupts(void) {}
+
 /* VBlank */
 static inline void wait_vbl_done(void) {}
 

--- a/tests/test_loader.c
+++ b/tests/test_loader.c
@@ -274,6 +274,33 @@ void test_load_asset_independent_of_state_flag(void) {
     TEST_ASSERT_NOT_EQUAL(0xFFu, loader_get_asset_slot(TILE_ASSET_DIALOG_ARROW));
 }
 
+/* ---- State manifest tests ---- */
+
+void test_playing_manifest_count_is_correct(void) {
+    TEST_ASSERT_EQUAL_UINT8(4u, k_playing_assets_count);
+}
+
+void test_overmap_manifest_count_is_correct(void) {
+    TEST_ASSERT_EQUAL_UINT8(2u, k_overmap_assets_count);
+}
+
+void test_hub_manifest_count_is_correct(void) {
+    TEST_ASSERT_EQUAL_UINT8(5u, k_hub_assets_count);
+}
+
+void test_playing_manifest_load_unload_cycle(void) {
+    loader_load_state(k_playing_assets, k_playing_assets_count);
+    /* All playing assets should have valid slots */
+    TEST_ASSERT_NOT_EQUAL(0xFFu, loader_get_asset_slot(TILE_ASSET_PLAYER));
+    TEST_ASSERT_NOT_EQUAL(0xFFu, loader_get_asset_slot(TILE_ASSET_BULLET));
+    TEST_ASSERT_NOT_EQUAL(0xFFu, loader_get_asset_slot(TILE_ASSET_TURRET));
+    TEST_ASSERT_NOT_EQUAL(0xFFu, loader_get_asset_slot(TILE_ASSET_TRACK));
+    loader_unload_state();
+    /* After unload, all slots cleared */
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, loader_get_asset_slot(TILE_ASSET_PLAYER));
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, loader_get_asset_slot(TILE_ASSET_TRACK));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_load_player_tiles_is_callable);
@@ -311,5 +338,9 @@ int main(void) {
     RUN_TEST(test_load_asset_assigns_sprite_slot);
     RUN_TEST(test_load_asset_assigns_bg_slot);
     RUN_TEST(test_load_asset_independent_of_state_flag);
+    RUN_TEST(test_playing_manifest_count_is_correct);
+    RUN_TEST(test_overmap_manifest_count_is_correct);
+    RUN_TEST(test_hub_manifest_count_is_correct);
+    RUN_TEST(test_playing_manifest_load_unload_cycle);
     return UNITY_END();
 }

--- a/tests/test_loader.c
+++ b/tests/test_loader.c
@@ -196,7 +196,7 @@ void test_set_track_0_restores_default_registry(void) {
 /* ---- loader_load_state / loader_unload_state tests ---- */
 
 void test_load_state_assigns_sprite_slot_in_range(void) {
-    static const tile_asset_t assets[] = { TILE_ASSET_PLAYER };
+    static const uint8_t assets[] = { TILE_ASSET_PLAYER };
     loader_load_state(assets, 1u);
     uint8_t slot = loader_get_asset_slot(TILE_ASSET_PLAYER);
     TEST_ASSERT_NOT_EQUAL(0xFFu, slot);
@@ -204,7 +204,7 @@ void test_load_state_assigns_sprite_slot_in_range(void) {
 }
 
 void test_load_state_assigns_bg_slot_in_range(void) {
-    static const tile_asset_t assets[] = { TILE_ASSET_TRACK };
+    static const uint8_t assets[] = { TILE_ASSET_TRACK };
     loader_load_state(assets, 1u);
     uint8_t slot = loader_get_asset_slot(TILE_ASSET_TRACK);
     TEST_ASSERT_NOT_EQUAL(0xFFu, slot);
@@ -212,14 +212,14 @@ void test_load_state_assigns_bg_slot_in_range(void) {
 }
 
 void test_unload_state_clears_slot_table(void) {
-    static const tile_asset_t assets[] = { TILE_ASSET_PLAYER };
+    static const uint8_t assets[] = { TILE_ASSET_PLAYER };
     loader_load_state(assets, 1u);
     loader_unload_state();
     TEST_ASSERT_EQUAL_UINT8(0xFFu, loader_get_asset_slot(TILE_ASSET_PLAYER));
 }
 
 void test_unload_state_allows_realloc_same_slot(void) {
-    static const tile_asset_t assets[] = { TILE_ASSET_PLAYER };
+    static const uint8_t assets[] = { TILE_ASSET_PLAYER };
     loader_load_state(assets, 1u);
     uint8_t slot1 = loader_get_asset_slot(TILE_ASSET_PLAYER);
     loader_unload_state();
@@ -229,7 +229,7 @@ void test_unload_state_allows_realloc_same_slot(void) {
 }
 
 void test_load_state_multiple_assets_no_overlap(void) {
-    static const tile_asset_t assets[] = {
+    static const uint8_t assets[] = {
         TILE_ASSET_PLAYER, TILE_ASSET_BULLET, TILE_ASSET_TURRET
     };
     loader_load_state(assets, 3u);
@@ -247,7 +247,7 @@ void test_load_state_multiple_assets_no_overlap(void) {
 }
 
 void test_get_slot_returns_valid_slot_after_load_state(void) {
-    static const tile_asset_t assets[] = { TILE_ASSET_PLAYER };
+    static const uint8_t assets[] = { TILE_ASSET_PLAYER };
     loader_load_state(assets, 1u);
     uint8_t slot = loader_get_slot(TILE_ASSET_PLAYER);
     TEST_ASSERT_TRUE(slot <= 63u);

--- a/tests/test_loader.c
+++ b/tests/test_loader.c
@@ -246,6 +246,34 @@ void test_load_state_multiple_assets_no_overlap(void) {
     TEST_ASSERT_TRUE(s2 <= 63u);
 }
 
+void test_get_slot_returns_valid_slot_after_load_state(void) {
+    static const tile_asset_t assets[] = { TILE_ASSET_PLAYER };
+    loader_load_state(assets, 1u);
+    uint8_t slot = loader_get_slot(TILE_ASSET_PLAYER);
+    TEST_ASSERT_TRUE(slot <= 63u);
+}
+
+void test_load_asset_assigns_sprite_slot(void) {
+    loader_load_asset(TILE_ASSET_BULLET);
+    uint8_t slot = loader_get_asset_slot(TILE_ASSET_BULLET);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, slot);
+    TEST_ASSERT_TRUE(slot <= 63u);
+}
+
+void test_load_asset_assigns_bg_slot(void) {
+    loader_load_asset(TILE_ASSET_OVERMAP_BG);
+    uint8_t slot = loader_get_asset_slot(TILE_ASSET_OVERMAP_BG);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, slot);
+    TEST_ASSERT_TRUE(slot >= 64u && slot <= 254u);
+}
+
+void test_load_asset_independent_of_state_flag(void) {
+    /* loader_load_asset should work with no state loaded */
+    /* setUp() resets bitmap and state_active = 0 */
+    loader_load_asset(TILE_ASSET_DIALOG_ARROW);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, loader_get_asset_slot(TILE_ASSET_DIALOG_ARROW));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_load_player_tiles_is_callable);
@@ -279,5 +307,9 @@ int main(void) {
     RUN_TEST(test_unload_state_clears_slot_table);
     RUN_TEST(test_unload_state_allows_realloc_same_slot);
     RUN_TEST(test_load_state_multiple_assets_no_overlap);
+    RUN_TEST(test_get_slot_returns_valid_slot_after_load_state);
+    RUN_TEST(test_load_asset_assigns_sprite_slot);
+    RUN_TEST(test_load_asset_assigns_bg_slot);
+    RUN_TEST(test_load_asset_independent_of_state_flag);
     return UNITY_END();
 }

--- a/tests/test_loader.c
+++ b/tests/test_loader.c
@@ -169,6 +169,30 @@ void test_registry_out_of_bounds_returns_null(void) {
     TEST_ASSERT_NULL(e);
 }
 
+void test_set_track_1_registry_is_bg_non_null(void) {
+    loader_set_track(1u);
+    const tile_registry_entry_t *e = loader_get_registry(TILE_ASSET_TRACK);
+    TEST_ASSERT_NOT_NULL(e);
+    TEST_ASSERT_NOT_NULL(e->data);
+    TEST_ASSERT_EQUAL_UINT8(0u, e->is_sprite);
+}
+
+void test_set_track_2_registry_is_bg_non_null(void) {
+    loader_set_track(2u);
+    const tile_registry_entry_t *e = loader_get_registry(TILE_ASSET_TRACK);
+    TEST_ASSERT_NOT_NULL(e);
+    TEST_ASSERT_NOT_NULL(e->data);
+    TEST_ASSERT_EQUAL_UINT8(0u, e->is_sprite);
+}
+
+void test_set_track_0_restores_default_registry(void) {
+    loader_set_track(1u);
+    loader_set_track(0u);
+    const tile_registry_entry_t *e = loader_get_registry(TILE_ASSET_TRACK);
+    TEST_ASSERT_NOT_NULL(e);
+    TEST_ASSERT_EQUAL_UINT8(0u, e->is_sprite);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_load_player_tiles_is_callable);
@@ -194,5 +218,8 @@ int main(void) {
     RUN_TEST(test_registry_track_is_bg);
     RUN_TEST(test_registry_hud_font_is_null_sentinel);
     RUN_TEST(test_registry_out_of_bounds_returns_null);
+    RUN_TEST(test_set_track_1_registry_is_bg_non_null);
+    RUN_TEST(test_set_track_2_registry_is_bg_non_null);
+    RUN_TEST(test_set_track_0_restores_default_registry);
     return UNITY_END();
 }

--- a/tests/test_loader.c
+++ b/tests/test_loader.c
@@ -193,6 +193,59 @@ void test_set_track_0_restores_default_registry(void) {
     TEST_ASSERT_EQUAL_UINT8(0u, e->is_sprite);
 }
 
+/* ---- loader_load_state / loader_unload_state tests ---- */
+
+void test_load_state_assigns_sprite_slot_in_range(void) {
+    static const tile_asset_t assets[] = { TILE_ASSET_PLAYER };
+    loader_load_state(assets, 1u);
+    uint8_t slot = loader_get_asset_slot(TILE_ASSET_PLAYER);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, slot);
+    TEST_ASSERT_TRUE(slot <= 63u);
+}
+
+void test_load_state_assigns_bg_slot_in_range(void) {
+    static const tile_asset_t assets[] = { TILE_ASSET_TRACK };
+    loader_load_state(assets, 1u);
+    uint8_t slot = loader_get_asset_slot(TILE_ASSET_TRACK);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, slot);
+    TEST_ASSERT_TRUE(slot >= 64u && slot <= 254u);
+}
+
+void test_unload_state_clears_slot_table(void) {
+    static const tile_asset_t assets[] = { TILE_ASSET_PLAYER };
+    loader_load_state(assets, 1u);
+    loader_unload_state();
+    TEST_ASSERT_EQUAL_UINT8(0xFFu, loader_get_asset_slot(TILE_ASSET_PLAYER));
+}
+
+void test_unload_state_allows_realloc_same_slot(void) {
+    static const tile_asset_t assets[] = { TILE_ASSET_PLAYER };
+    loader_load_state(assets, 1u);
+    uint8_t slot1 = loader_get_asset_slot(TILE_ASSET_PLAYER);
+    loader_unload_state();
+    loader_load_state(assets, 1u);
+    uint8_t slot2 = loader_get_asset_slot(TILE_ASSET_PLAYER);
+    TEST_ASSERT_EQUAL_UINT8(slot1, slot2);
+}
+
+void test_load_state_multiple_assets_no_overlap(void) {
+    static const tile_asset_t assets[] = {
+        TILE_ASSET_PLAYER, TILE_ASSET_BULLET, TILE_ASSET_TURRET
+    };
+    loader_load_state(assets, 3u);
+    uint8_t s0 = loader_get_asset_slot(TILE_ASSET_PLAYER);
+    uint8_t s1 = loader_get_asset_slot(TILE_ASSET_BULLET);
+    uint8_t s2 = loader_get_asset_slot(TILE_ASSET_TURRET);
+    /* All allocated (not sentinel) */
+    TEST_ASSERT_NOT_EQUAL(0xFFu, s0);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, s1);
+    TEST_ASSERT_NOT_EQUAL(0xFFu, s2);
+    /* All in sprite region */
+    TEST_ASSERT_TRUE(s0 <= 63u);
+    TEST_ASSERT_TRUE(s1 <= 63u);
+    TEST_ASSERT_TRUE(s2 <= 63u);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_load_player_tiles_is_callable);
@@ -221,5 +274,10 @@ int main(void) {
     RUN_TEST(test_set_track_1_registry_is_bg_non_null);
     RUN_TEST(test_set_track_2_registry_is_bg_non_null);
     RUN_TEST(test_set_track_0_restores_default_registry);
+    RUN_TEST(test_load_state_assigns_sprite_slot_in_range);
+    RUN_TEST(test_load_state_assigns_bg_slot_in_range);
+    RUN_TEST(test_unload_state_clears_slot_table);
+    RUN_TEST(test_unload_state_allows_realloc_same_slot);
+    RUN_TEST(test_load_state_multiple_assets_no_overlap);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Adds `loader_set_track` + per-track BG tile registry dispatch (with `disable_interrupts()` halts and if-else index to avoid non-power-of-two multiply)
- Adds `loader_load_state` / `loader_unload_state` with a shared `loader_do_load_one` helper; fixes bank-switch ordering so `*count_ptr` is always read from the correct asset ROM bank
- Adds `loader_get_slot` (asserting), `loader_load_asset` (single-asset loader), and three ROM-resident state manifests (`k_playing_assets`, `k_overmap_assets`, `k_hub_assets`) as `uint8_t[]` (not `tile_asset_t[]`) to avoid 2-byte SDCC enum elements
- Adds `disable_interrupts` / `enable_interrupts` no-op stubs to test mock

## Test Plan
- [ ] `make test` passes (39 loader tests + 9 track dispatch tests, 0 failures)
- [ ] Emulicious smoketest confirmed by user (title, overmap, race, hub — no regression)
- [ ] bank-post-build: ROM_0 91% WARN, ROM_1 98% WARN, ROM_2 85% WARN (non-blocking, pre-existing)
- [ ] gb-memory-validator: WRAM 12%, VRAM 5%, OAM 77% — all PASS

Closes #293