### PR TITLE
fix(banking): pin music_data.c to bank 31 to isolate from game data

### DIFF
--- a/bank-manifest.json
+++ b/bank-manifest.json
@@ -12,7 +12,7 @@
   "src/hud.c":                   {"bank": 255, "reason": "autobank"},
   "src/main.c":                  {"bank": 0,   "reason": "game entry / VBL handling — no #pragma bank"},
   "src/music.c":                 {"bank": 0,   "reason": "VBL ISR music_tick must be in HOME bank — no #pragma bank"},
-  "src/music_data.c":            {"bank": 2,   "reason": "explicit pin — 11 KB data file; autobank would fill bank 1 to 100%"},
+  "src/music_data.c":            {"bank": 31,  "reason": "explicit pin — 11 KB data file; pinned to last bank (31) to permanently isolate music from all game data banks"},
   "src/npc_drifter_portrait.c":  {"bank": 255, "reason": "autobank — loader.c handles BANK(sym) switching"},
   "src/npc_mechanic_portrait.c": {"bank": 255, "reason": "autobank — loader.c handles BANK(sym) switching"},
   "src/npc_trader_portrait.c":   {"bank": 255, "reason": "autobank — loader.c handles BANK(sym) switching"},

--- a/src/music_data.c
+++ b/src/music_data.c
@@ -1,4 +1,4 @@
-#pragma bank 2
+#pragma bank 31
 #include <gb/gb.h>
 #include <stddef.h>
 #include "banking.h"


### PR DESCRIPTION
## Summary
- `music_data.c` was sharing bank 2 with `track_tile_data` and autobanked overflow (`track3_map`, `overmap_car_sprite`), causing music stall and car freeze during races
- Pinned `music_data.c` to bank 31 (last bank, permanently isolated from all game data)
- Updated `bank-manifest.json` reason string to document the isolation rule

## Test Plan
- [x] `make test` passes (9/9)
- [x] `bank-post-build` gates passed (ROM_31: 61% PASS, bank 2 freed to 24%)
- [x] Emulicious smoketest confirmed by user — race with car stationary, no music stall, no freeze
- [x] No FAIL budgets in memory-check

Closes #321