### PR TITLE
docs(agents): update gbdk-expert with loader_load_state/tile_base and camera_set_tile_base patterns

### DIFF
--- a/.claude/agents/gbdk-expert.md
+++ b/.claude/agents/gbdk-expert.md
@@ -65,7 +65,7 @@ write call before `player_update()`.
 - MBC bank switching questions → use bank-pre-write / bank-post-build skills
 - `set_sprite_tile()` index is absolute tile number in OBJ tile data, not relative
 - **BANKED keyword missing on autobank functions called from bank 0:** autobank only assigns bank numbers at link time — it does NOT generate `__call_banked` trampolines. Any `#pragma bank 255` function called from bank-0 code (`main.c`, `loader.c`, etc.) MUST have `BANKED` on both the `.h` declaration and the `.c` definition; the header must `#include <gb/gb.h>`. Without it, SDCC emits a direct `call _funcname` → wrong bank mapped at runtime → crash. `static` functions must NOT be `BANKED`. See `src/player.h` for the canonical pattern. The mock defines `BANKED` as empty so host tests compile unchanged.
-- **Banked modules calling `set_sprite_data`/`set_bkg_data` directly:** These VRAM writes require `SWITCH_ROM` to load the asset bank, but calling `SWITCH_ROM` from banked code switches away the bank the running function lives in → crash. All VRAM tile loading must go through a NONBANKED wrapper in `loader.c` (bank 0). Add a `load_<asset>_tiles()` NONBANKED function to `loader.c` (mirror `load_bullet_tiles()`), declare it in `loader.h`, call it from the module's init. Never call `set_sprite_data()` or `set_bkg_data()` from a `#pragma bank 255` file.
+- **Banked modules calling `set_sprite_data`/`set_bkg_data` directly:** These VRAM writes require `SWITCH_ROM` to load the asset bank, but calling `SWITCH_ROM` from banked code switches away the bank the running function lives in → crash. All VRAM tile loading must go through `loader_load_state()` (NONBANKED, bank 0). Module inits accept a `uint8_t tile_base` parameter (set by the state coordinator via `loader_get_slot(TILE_ASSET_X)` after `loader_load_state()` completes); modules call `set_sprite_tile(id, tile_base + relative_offset)` but never call `set_sprite_data()` or `set_bkg_data()` directly. Never call `set_sprite_data()` or `set_bkg_data()` from a `#pragma bank 255` file.
 - **BANKED functions reading ROM data from a different bank → silent data corruption:** If a `BANKED` function (e.g. in bank 1) dereferences a pointer or reads an array that lives in a different bank (e.g. bank 2), the read silently returns bytes from the WRONG bank — no crash, no assert. This bites when the autobanker reassigns data to a new bank (e.g. because another file in the same bank grew). The fix: all cross-bank ROM reads from `BANKED` functions must be routed through a `NONBANKED` (bank 0) helper in `loader.c` that does `SWITCH_ROM / read / SWITCH_ROM(saved)`. **`BANKED` functions CAN safely call `NONBANKED` helpers** — the helper runs from bank 0 (never unmaped), switches in the target bank, reads, restores, and returns. Pattern: `loader_map_read_byte(idx)`, `loader_map_fill_row(ty, w, buf)` in `src/loader.c`. Never dereference a ROM pointer in a `BANKED` function if that data might be in a different autobank than the function itself.
 - **`cls()` corrupts the track tilemap:** `cls()` writes all 32 BG tilemap rows. `camera_init()` only restores rows 0–17; rows 18–31 stay corrupted, breaking tile-based detection (finish line, checkpoints). Never call `cls()` in a state that precedes `state_playing`. Clear text rows 0–17 only with a `set_bkg_tile_xy` loop using tile `0x00u` for space — NOT `0x20u`. GBDK's font maps ASCII space (0x20) to tile index 0x00; writing 0x20 renders '@', not space.
 - **Large VRAM loop in `update()` causes spurious VBlank → `KEY_TICKED` always false:** A full-screen BG clear (18×20 = 360 `set_bkg_tile_xy` calls) spans more than one frame. The spurious VBlank unblocks the main loop, calls `input_update()` a second time, overwrites `prev_input` — `KEY_TICKED` returns false for every press. Full BG clears belong in `enter()` under `DISPLAY_OFF` only. `update()` must only redraw changed cells. Diagnosis: read `input` and `prev_input` from WRAM after a button press — if both equal the pressed value, `input_update()` ran twice.
@@ -73,6 +73,7 @@ write call before `player_update()`.
 - **`static` header functions dereferencing raw WRAM addresses segfault on GCC host tests:** `(volatile uint8_t *)0xDF80` is valid in GBC address space but causes an immediate segfault on Linux. Any debug function in a header that writes to fixed WRAM/hardware addresses must be wrapped: `#ifdef __SDCC` for the real write, `#else` for a no-op stub. Example: `#ifdef __SDCC\n#define DBG_TICK_INC() do { (*(volatile uint8_t *)DEBUG_TICK_ADDR)++; } while(0)\n#else\n#define DBG_TICK_INC() do {} while(0)\n#endif`
 - **New GBDK API call added to `src/` but not mocked:** `make test` fails with "undefined reference" if the function has no `static inline` stub in `tests/mocks/gb/gb.h`. Before committing any new `src/*.c` that calls an unmocked GBDK function, `grep tests/mocks/gb/gb.h` for the function name and add a no-op stub if missing.
 - **`loader_load_state()` added to `enter()` → tests that call `enter()` twice hang forever:** `loader_load_state()` asserts (`disable_interrupts(); while(1){}`) on double-load. Any test file for a state that calls `enter()` more than once (setUp calls it, then a test body calls it again) will spin at 100% CPU indefinitely — `make test` never returns. **Fix:** after adding `loader_load_state()` to `enter()`, grep the test file for additional `enter()` calls outside setUp and add `state_X.exit(); loader_reset_bitmap_for_test();` immediately before each one. Always run `make test` with `timeout 30` so a hang surfaces as a timeout failure instead of a silent spin.
+- **BG tilemap entries garbled after removing legacy `load_track_tiles()` → must call `camera_set_tile_base()`:** `track_fill_row_range()` / `track_fill_col()` return raw 0-based tile type indices (0, 1, 2 …). The legacy `load_track_tiles()` called `set_bkg_data(0, …)` — raw index 0 correctly pointed to VRAM slot 0. The loader assigns TILE_ASSET_TRACK to LOADER_BG_START (143). Without an offset, BG tilemap entries 0/1/2 point to the printf font (tiles 0–127) instead of track tiles — result: garbled BG and invisible text. Fix: `camera_set_tile_base(loader_get_slot(TILE_ASSET_TRACK))` MUST be called before `camera_init()` in `state_playing.enter()`. The camera's stream functions (`stream_row`, `stream_col`, `stream_row_direct`) add this base to every raw tile index before writing to the BG tilemap. Any future module writing raw tile-type indices to the BG tilemap must apply the same pattern.
 - **Hardware register mocks declared `static` in header:** `static uint8_t` in a mock header gives each translation unit its own independent copy — `sfx.c` writes its copy of `NR44_REG`; `test_sfx.c` reads its own (still 0). Any new register observable from a test file must be `extern uint8_t` declared in the header and defined in `tests/mocks/hardware_regs.c` (auto-picked up by `MOCK_SRCS := $(wildcard tests/mocks/*.c)`).
 
 ### Banking Architecture (post-autobank-migration)
@@ -80,13 +81,22 @@ write call before `player_update()`.
 **Invariant:** Only bank-0 files (no `#pragma bank`) may call `SET_BANK` or `SWITCH_ROM`.
 Files with `#pragma bank 255` (autobank) or explicit bank N: call BANKED functions or NONBANKED loader wrappers — never touch `SWITCH_ROM` directly.
 
-**loader.c pattern** — bank-0 NONBANKED wrappers for VRAM asset loads:
+**loader.c / tile_base pattern** — `loader_load_state()` (NONBANKED, bank 0) loads all assets for the current state into VRAM. The state coordinator then calls each module init with the assigned slot:
+
 ```c
-void load_player_tiles(void) NONBANKED {
-    uint8_t saved = CURRENT_BANK;
-    SWITCH_ROM(BANK(player_tile_data));
-    set_sprite_data(0, player_tile_data_count, player_tile_data);
-    SWITCH_ROM(saved);
+/* In state_playing.enter(): */
+loader_load_state(&playing_state_manifest);
+player_init(loader_get_slot(TILE_ASSET_PLAYER));      /* e.g. slot 0 */
+projectile_init(loader_get_slot(TILE_ASSET_BULLET));  /* e.g. slot 17 */
+enemy_init(loader_get_slot(TILE_ASSET_TURRET));       /* e.g. slot 18 */
+camera_set_tile_base(loader_get_slot(TILE_ASSET_TRACK)); /* e.g. slot 143 */
+camera_init();
+
+/* In player.c: */
+void player_init(uint8_t tile_base) BANKED {
+    s_player_tile_base = tile_base;
+    /* ... */
+    set_sprite_tile(0, s_player_tile_base + 0u);  /* never set_sprite_data() */
 }
 ```
 


### PR DESCRIPTION
## Summary
- Replace stale `load_bullet_tiles()` mirror reference with the current `loader_load_state()` + `tile_base` parameter pattern
- Replace stale `load_player_tiles()` code example with the state coordinator pattern (state calls `loader_get_slot()`, passes result to module init)
- Add new Common Bugs entry: BG tilemap garbled if `camera_set_tile_base()` is not called before `camera_init()` after removing legacy track loader

## Test Plan
- [ ] Doc-only change — no C files touched
- [ ] Clean ROM build passes