### PR TITLE
docs: music-expert implementation mode (issue #300)

### DIFF
--- a/.claude/agents/music-expert.md
+++ b/.claude/agents/music-expert.md
@@ -374,3 +374,28 @@ Safe procedure for re-triggering CH3:
 ### Version Pinning
 
 hUGETracker and hUGEDriver **must match exactly** (e.g. hUGETracker 1.0b10 requires hUGEDriver 1.0b10). The data format changes between versions — mismatches produce silent corruption or crashes. This project vendors **v6.1.3**. Do not update one without the other.
+
+---
+
+## Implementation Mode
+
+When called with a prompt starting with **"implement this task: …"**, act as the music implementer — execute the full music pipeline end-to-end, not just explain scenarios.
+
+**Trigger phrase:** `implement this task: <full task text from plan>`
+
+**Behavior in implementation mode:**
+1. Read the full task text and identify all files to create or modify.
+2. Invoke the `bank-pre-write` skill (HARD GATE) before writing any `src/*.c` or `src/*.h` file. Verify `bank-manifest.json` has an entry for every new music file.
+3. Execute the pipeline from Scenario 1:
+   - Export from hUGETracker (hUGEDriver v6.1.3 format)
+   - Add `#pragma bank 255`, `#include <gb/gb.h>`, `#include "banking.h"`, and `BANKREF(name)` to the exported `.c` file
+   - Rename the exported `const hUGESong_t` variable to match the `BANKREF` name
+   - Run `python3 tools/music_song_validate.py src/music_data.c` — fix all errors before continuing
+   - Update `src/music_data.h` with `BANKREF_EXTERN` and `extern const hUGESong_t` declarations
+   - Wire `src/music.c` calls (`SET_BANK`, `hUGE_init`) in `music_init()`
+   - Run `python3 tools/music_wire_check.py` — fix all errors before continuing
+4. Build the ROM (`GBDK_HOME=/home/mathdaman/gbdk make` → PASS).
+5. Invoke the `bank-post-build` skill (HARD GATE) after a successful build.
+6. Commit.
+
+**Consultation mode is unchanged** — when called with a question (not "implement this task: …"), answer as normal.

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -64,7 +64,8 @@ NEVER use `git merge master` alone — the local master ref may be stale. Resolv
 For each task (whether parallel or sequential):
 1. Mark as in_progress
 2. Determine task type:
-   - **C task** (creates or modifies `src/*.c` or `src/*.h`): dispatch `gbdk-expert` agent (Agent tool) with prompt `"implement this task: <full task text from plan>"`. `gbdk-expert` owns the full TDD cycle, bank gates, build, `gb-c-optimizer` review AND fix (fixes applied in-place before commit), and commit for this task.
+   - **Music C task** (creates or modifies `src/music_data.c`, `src/music_data.h`, or any new song `.c` file): dispatch `music-expert` agent (Agent tool) with prompt `"implement this task: <full task text from plan>"`. `music-expert` owns the full music pipeline (export, BANKREF declarations, `music_song_validate.py`, `music_wire_check.py`, bank-pre-write gate, build, bank-post-build gate, commit) for this task.
+   - **C task** (creates or modifies other `src/*.c` or `src/*.h` files): dispatch `gbdk-expert` agent (Agent tool) with prompt `"implement this task: <full task text from plan>"`. `gbdk-expert` owns the full TDD cycle, bank gates, build, `gb-c-optimizer` review AND fix (fixes applied in-place before commit), and commit for this task.
    - **Non-C task** (docs, Python, JSON, assets): follow each step exactly as written in the plan.
 2a. **Post-dispatch commit verification (all implementer agents):** After the agent returns, run:
    ```bash

--- a/.claude/skills/subagent-driven-development/SKILL.md
+++ b/.claude/skills/subagent-driven-development/SKILL.md
@@ -113,7 +113,13 @@ When dispatching the implementer subagent, include ALL of the following in the p
 2. Scene-setting context (where this task fits in the overall feature)
 3. **C task routing:**
 
-   If the task creates or modifies `src/*.c` or `src/*.h`, the implementer IS `gbdk-expert`. Dispatch the `gbdk-expert` agent (Agent tool) with:
+   **Music C task** — if the task creates or modifies `src/music_data.c`, `src/music_data.h`, or any new song `.c` file, the implementer IS `music-expert`. Dispatch the `music-expert` agent (Agent tool) with:
+
+   > implement this task: <full task text from plan>
+
+   `music-expert` owns the full music pipeline: export, BANKREF declarations, `music_song_validate.py`, `music_wire_check.py`, bank-pre-write gate, build, bank-post-build gate, and commit. Do NOT include separate gate instructions — `music-expert`'s own body enforces them.
+
+   **All other C tasks** — if the task creates or modifies other `src/*.c` or `src/*.h` files, the implementer IS `gbdk-expert`. Dispatch the `gbdk-expert` agent (Agent tool) with:
 
    > implement this task: <full task text from plan>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ Always use `gh` for git push/pull and GitHub operations. Run `gh auth setup-git`
 - **`map-expert`** — Autonomous map agent: executes end-to-end map creation pipeline AND holds domain knowledge (Tiled TMX format, Python converters (`tmx_to_c`, `png_to_tiles`), GB BG tilemap hardware). Use when creating or modifying maps. **Update this agent in the same PR** whenever the pipeline changes.
 - **`sprite-expert`** — Autonomous sprite agent: Aseprite pipeline, `png_to_tiles.py`, OAM management, CGB palettes, coordinate system, and end-to-end execution checklist with self-correction retry loop. Use when creating or modifying sprites. **Update this agent in the same PR** whenever the sprite system changes.
 - **`emulicious-debug`** — Step-through debugger, breakpoints, `EMU_printf`, memory/tile/sprite inspection, tracer, profiler, romusage. Appends a machine-readable `\`\`\`json` block as the last element of every response (schema: `bank`, `address`, `symptom`, `registers[]`, `stack_trace`, `hypothesis`; unknown fields emit `null`).
-- **`music-expert`** — Music driver integration, hUGEDriver patterns, music_tick placement, bank-safe calls.
+- **`music-expert`** — Music driver integration, hUGEDriver patterns, music_tick placement, bank-safe calls. Consultation mode: ask about audio issues, hUGEDriver API, channel routing. Implementation mode: dispatch with `"implement this task: <task text>"` to execute the full music pipeline end-to-end (export, BANKREF declarations, wiring, `music_song_validate.py` + `music_wire_check.py` validation, bank gates).
 
 ### Skills (in `.claude/skills/`, invoked with the Skill tool)
 


### PR DESCRIPTION
## Summary

- Adds `## Implementation Mode` section to `music-expert.md` triggered by `"implement this task: …"` — covers full pipeline: bank-pre-write gate, export, BANKREF declarations, `music_song_validate.py`, `music_wire_check.py`, build, bank-post-build gate, commit
- Updates `CLAUDE.md` `music-expert` entry to document both consultation and implementation modes
- Updates `executing-plans` skill to route music C tasks (`src/music_data.c`, `src/music_data.h`, new song files) to `music-expert` instead of `gbdk-expert`
- Updates `subagent-driven-development` skill with the same music task routing in the implementer dispatch block

## Test plan

- [x] Doc-only change — no `.c`/`.h` files touched
- [x] Clean build passes (zero errors)
- [x] Smoketest in Emulicious confirmed no regressions
- [x] All four files ship in a single PR (AC7)

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)