### PR TITLE
fix(camera): use HUD_SCANLINE for cam_max_y — bottom 2 tile rows were hidden behind HUD

### DIFF
--- a/src/camera.c
+++ b/src/camera.c
@@ -2,6 +2,7 @@
 #include <gb/gb.h>
 #include "camera.h"
 #include "track.h"
+#include "config.h"
 
 volatile uint16_t cam_y;
 volatile uint8_t  cam_scy_shadow;
@@ -17,7 +18,7 @@ static uint16_t clamp_cam(int16_t v, uint16_t max) {
     return (uint16_t)v;
 }
 
-/* cam_max_y = active_map_h * 8 - 144 (computed inline — cheaper than WRAM var) */
+/* cam_max_y = active_map_h * 8 - HUD_SCANLINE (computed inline — cheaper than WRAM var) */
 /* cam_max_x = active_map_w * 8 - 160 (computed inline) */
 
 /* --- Row streaming ------------------------------------------------------- */
@@ -122,7 +123,7 @@ void camera_init(int16_t player_world_x, int16_t player_world_y) BANKED {
     stream_row_buf_len = 0u;
     stream_col_buf_len = 0u;
 
-    cam_max_y = (uint16_t)active_map_h * 8u - 144u;
+    cam_max_y = (uint16_t)active_map_h * 8u - (uint16_t)HUD_SCANLINE;
     cam_max_x = (active_map_w > 20u) ? ((uint16_t)active_map_w * 8u - 160u) : 0u;
 
     cam_y = clamp_cam(player_world_y - 72, cam_max_y);
@@ -146,7 +147,7 @@ void camera_update(int16_t player_world_x, int16_t player_world_y) BANKED {
     uint8_t old_left, new_left;
     uint8_t old_right, new_right;
 
-    cam_max_y = (uint16_t)active_map_h * 8u - 144u;
+    cam_max_y = (uint16_t)active_map_h * 8u - (uint16_t)HUD_SCANLINE;
     cam_max_x = (active_map_w > 20u) ? ((uint16_t)active_map_w * 8u - 160u) : 0u;
 
     ncy = clamp_cam(player_world_y - 72, cam_max_y);

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -1,6 +1,5 @@
 #pragma bank 255
 #include <gb/gb.h>
-#include <gbdk/emu_debug.h>
 #include "banking.h"
 #include "input.h"
 #include "state_manager.h"
@@ -65,7 +64,6 @@ static void enter(void) {
     track_init();
     checkpoint_init(track_get_checkpoints(), track_get_checkpoint_count());
     camera_set_tile_base(loader_get_slot(TILE_ASSET_TRACK));
-    EMU_printf("DBG active_map_h=%d active_map_w=%d\n", (int)active_map_h, (int)active_map_w);
     camera_init(player_get_x(), player_get_y());
     hud_init(track_get_map_type(), track_get_lap_count());
     hud_set_lap(lap_get_current(), lap_get_total());

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -1,5 +1,6 @@
 #pragma bank 255
 #include <gb/gb.h>
+#include <gbdk/emu_debug.h>
 #include "banking.h"
 #include "input.h"
 #include "state_manager.h"
@@ -64,6 +65,7 @@ static void enter(void) {
     track_init();
     checkpoint_init(track_get_checkpoints(), track_get_checkpoint_count());
     camera_set_tile_base(loader_get_slot(TILE_ASSET_TRACK));
+    EMU_printf("DBG active_map_h=%d active_map_w=%d\n", (int)active_map_h, (int)active_map_w);
     camera_init(player_get_x(), player_get_y());
     hud_init(track_get_map_type(), track_get_lap_count());
     hud_set_lap(lap_get_current(), lap_get_total());

--- a/tests/test_camera.c
+++ b/tests/test_camera.c
@@ -29,10 +29,10 @@ void test_camera_init_clamps_cam_y_to_zero(void) {
     TEST_ASSERT_EQUAL_UINT16(0, cam_y);
 }
 
-/* Player past bottom: cam_y capped at CAM_MAX_Y = 656 */
+/* Player past bottom: cam_y capped at CAM_MAX_Y = 672 (100*8 - HUD_SCANLINE=128) */
 void test_camera_init_clamps_cam_y_to_max(void) {
-    camera_init(80, 800);  /* 800-72=728 > 656 -> 656 */
-    TEST_ASSERT_EQUAL_UINT16(656, cam_y);
+    camera_init(80, 800);  /* 800-72=728 > 672 -> 672 */
+    TEST_ASSERT_EQUAL_UINT16(672, cam_y);
 }
 
 /* --- camera_init: preloads exactly 18 rows, not all 100 ----------------- */


### PR DESCRIPTION
## Summary
- `cam_max_y` was computed as `active_map_h * 8 - 144` (full screen height), causing the bottom 16px (2 tile rows) of every track to scroll behind the HUD window and never be visible to the player
- Fixed by replacing `144u` with `(uint16_t)HUD_SCANLINE` (128) in both `camera_init()` and `camera_update()` in `src/camera.c`
- Updated `tests/test_camera.c` assertion to expect the correct max value (672 instead of 656 for a 100-tile map)

## Test Plan
- [x] `make test` passes
- [x] Emulicious smoketest confirmed — track 2 bottom section now fully visible above HUD
- [x] bank-post-build gate passed
- [x] gb-memory-validator: all budgets PASS

Closes #335