### PR TITLE
feat: directional hitbox for player car collision

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -386,7 +386,8 @@
       "Bash(Tiled *)",
       "Bash(timeout 10 /tmp/test_track *)",
       "Bash(awk '{print $1}')",
-      "Bash(xargs -r kill -9)"
+      "Bash(xargs -r kill -9)",
+      "Bash(timeout 10 ./build/test_player_tmp *)"
     ]
   },
   "hooks": {

--- a/src/player.c
+++ b/src/player.c
@@ -97,12 +97,39 @@ static uint8_t corner_active_turret(int16_t wx, int16_t wy) {
     return enemy_blocks_tile(tx, ty);
 }
 
-/* Returns 1 if all 4 corners of the 16×16 hitbox at (wx, wy) are on track. */
+/* Directional hitbox points indexed by player_dir_t (0-7).
+ * Cardinal dirs: rectangle inset ~2px on sides perpendicular to travel.
+ * Diagonal dirs: diamond with points at edge midpoints. */
+static const uint8_t HITBOX_X[8][4] = {
+    {2u, 13u,  2u, 13u},  /* DIR_T  */
+    {8u, 14u,  1u,  8u},  /* DIR_RT */
+    {0u, 15u,  0u, 15u},  /* DIR_R  */
+    {1u,  8u,  8u, 14u},  /* DIR_RB */
+    {2u, 13u,  2u, 13u},  /* DIR_B  */
+    {8u, 14u,  1u,  8u},  /* DIR_LB */
+    {0u, 15u,  0u, 15u},  /* DIR_L  */
+    {1u,  8u,  8u, 14u},  /* DIR_LT */
+};
+static const uint8_t HITBOX_Y[8][4] = {
+    {0u,  0u, 15u, 15u},  /* DIR_T  */
+    {1u,  8u,  8u, 14u},  /* DIR_RT */
+    {2u,  2u, 13u, 13u},  /* DIR_R  */
+    {8u,  1u, 14u,  8u},  /* DIR_RB */
+    {0u,  0u, 15u, 15u},  /* DIR_B  */
+    {1u,  8u,  8u, 14u},  /* DIR_LB */
+    {2u,  2u, 13u, 13u},  /* DIR_L  */
+    {8u,  1u, 14u,  8u},  /* DIR_LT */
+};
+
+/* Returns 1 if all 4 directional hitbox points at (wx, wy) are on track. */
 static uint8_t corners_passable(int16_t wx, int16_t wy) {
-    return track_passable(wx,        wy      ) && !corner_active_turret(wx,        wy      ) &&
-           track_passable(wx + 15,   wy      ) && !corner_active_turret(wx + 15,   wy      ) &&
-           track_passable(wx,        wy + 15 ) && !corner_active_turret(wx,        wy + 15 ) &&
-           track_passable(wx + 15,   wy + 15 ) && !corner_active_turret(wx + 15,   wy + 15 );
+    uint8_t i;
+    for (i = 0u; i < 4u; i++) {
+        int16_t cx = wx + HITBOX_X[player_dir][i];
+        int16_t cy = wy + HITBOX_Y[player_dir][i];
+        if (!track_passable(cx, cy) || corner_active_turret(cx, cy)) return 0u;
+    }
+    return 1u;
 }
 
 void player_init(uint8_t tile_base) BANKED {

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -118,13 +118,6 @@ static void update(void) {
          * - vy > 0 guard: only count when moving downward (prevents backward crossing)
          * - checkpoint_all_cleared() gate: all CPs must be crossed in order */
         ct = track_tile_type((int16_t)(px + 4), (int16_t)(py + 4));
-        /* DEBUG: show tile type + passability in HUD row 1 cols 18-19 */
-        {
-            uint8_t dbg[2];
-            dbg[0] = 128u + (uint8_t)ct;
-            dbg[1] = 128u + track_passable((int16_t)(px + 4), (int16_t)(py + 4));
-            set_win_tiles(18u, 1u, 2u, 1u, dbg);
-        }
         if (ct == TILE_FINISH) {
             if (finish_eval(active_map_type_cache, finish_armed,
                             pvx, pvy, finish_dir_cache,

--- a/tests/test_player.c
+++ b/tests/test_player.c
@@ -489,6 +489,39 @@ void test_bullet_spawn_northeast(void) {
     TEST_ASSERT_EQUAL_UINT8( 20u, projectile_get_y(0u));
 }
 
+/* --- directional hitbox ------------------------------------------------- */
+
+/* AC1: driving straight into a wall still blocks */
+void test_hitbox_cardinal_wall_blocks(void) {
+    /* Road: cols 4-15 (x=32-127). Left wall at col 3 (x=24-31).
+     * Player at x=32 (leftmost road tile), driving left.
+     * DIR_L hitbox X offsets: {0,15,0,15} — left points at new_px+0=30 -> col 3 = wall */
+    player_set_pos(32, 80);
+    input = J_LEFT | J_A;
+    player_update();
+    TEST_ASSERT_EQUAL_INT16(32, player_get_x());
+}
+
+/* AC2: driving diagonally along a wall no longer triggers phantom collisions */
+void test_hitbox_diagonal_along_wall_passes(void) {
+    /* Player hugging the left wall at x=32, driving DIR_RT (northeast).
+     * DIR_RT hitbox X offsets: {8,14,1,8}.
+     * new_px = 32+2 = 34; leftmost point = 34+1 = 35 -> col 4 (road) -> passes. */
+    player_set_pos(32, 80);
+    input = J_RIGHT | J_UP | J_A;
+    player_update();
+    TEST_ASSERT_TRUE(player_get_x() > 32);
+}
+
+/* AC1: wall collision deals 1 damage */
+void test_hitbox_cardinal_damage_on_collision(void) {
+    uint8_t hp_before = damage_get_hp();
+    player_set_pos(32, 80);
+    input = J_LEFT | J_A;
+    player_update();   /* blocked by left wall -> damage_wall_hit() */
+    TEST_ASSERT_EQUAL_UINT8(hp_before - 1u, damage_get_hp());
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_player_init_sets_start_position);
@@ -557,5 +590,9 @@ int main(void) {
     RUN_TEST(test_bullet_spawn_east);
     RUN_TEST(test_bullet_spawn_west);
     RUN_TEST(test_bullet_spawn_northeast);
+    /* AC: directional hitbox */
+    RUN_TEST(test_hitbox_cardinal_wall_blocks);
+    RUN_TEST(test_hitbox_diagonal_along_wall_passes);
+    RUN_TEST(test_hitbox_cardinal_damage_on_collision);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Replace fixed 16×16 square hitbox with 8 direction-specific point tables (`HITBOX_X[8][4]`, `HITBOX_Y[8][4]`) in `player.c`
- Rewrite `corners_passable()` to loop over 4 directional points instead of hardcoded corners — eliminates phantom wall collisions when driving diagonally
- Remove temporary debug HUD block (tile type + passability at cols 18–19 row 1) from `state_playing.c`

## Test Plan
- [x] `make test` passes (66 tests, 31 binaries)
- [x] Emulicious smoketest confirmed by user — diagonal along wall no longer triggers phantom collisions
- [x] `bank-post-build` gates passed
- [x] `make memory-check`: WRAM 13%, VRAM 16%, OAM 77% — all PASS

Closes #350