### PR TITLE
feat: turret 16-direction aim, wind-up timer, screen-visibility gate

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -387,7 +387,9 @@
       "Bash(timeout 10 /tmp/test_track *)",
       "Bash(awk '{print $1}')",
       "Bash(xargs -r kill -9)",
-      "Bash(timeout 10 ./build/test_player_tmp *)"
+      "Bash(timeout 10 ./build/test_player_tmp *)",
+      "Bash(timeout 10 /tmp/test_enemy *)",
+      "Bash(timeout 10 build/test_projectile)"
     ]
   },
   "hooks": {

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Or load `build/nuke-raider.gb` in any GB/GBC emulator ([Emulicious](https://emul
 | Music | `src/music.c/.h`, `src/music_data.c/.h` | hUGEDriver music playback |
 | SFX | `src/sfx.c/.h` | One-shot sound effects: CH4 noise (SFX_SHOOT, SFX_HIT) and CH1 tone sweep (SFX_HEAL, SFX_UI); bank-0 NONBANKED |
 | NPC portraits | `src/npc_*_portrait.c/.h` | Per-NPC portrait tile data |
-| Enemy | `src/enemy.c/.h` | Static turret emplacements: SoA pool, fire timer, collision detection, OAM render; turrets fire on frame 1 (timer init 0) and are not gated by player cooldown |
+| Enemy | `src/enemy.c/.h` | Static turret emplacements: SoA pool, 16-direction aim, fire timer (30-frame wind-up on first appearance, 45-frame interval), screen-visibility gate (no fire or hit-detect while off-screen), collision detection, OAM render |
 | Powerup | `src/powerup.c/.h` | One-shot tile-based powerup system: SoA pool (MAX_POWERUPS=4), OAM sprite per powerup, tile-overlap collect; POWERUP_TYPE_HEAL restores 50 HP and plays SFX_HEAL |
 | Loader | `src/loader.c/.h` | Bank-0 NONBANKED wrappers for VRAM asset loading and map data (NPC/powerup positions) |
 | Input | `src/input.h` | Key tick/press/release/debounce helpers |

--- a/src/config.h
+++ b/src/config.h
@@ -97,14 +97,15 @@
 /* Enemy pool */
 /* Turret sprite: slot assigned at runtime via loader_get_slot(TILE_ASSET_TURRET). */
 #define MAX_ENEMIES           8u
-#define TURRET_FIRE_INTERVAL 60u    /* frames between shots */
+#define TURRET_FIRE_INTERVAL 45u    /* frames between shots (~0.75 s at 60 fps) */
+#define TURRET_WIND_UP       30u    /* grace period on spawn before first shot */
 #define TURRET_HP             1u    /* hits to destroy */
 #define TURRET_HIT_RADIUS     4u    /* px radius for collision detection */
 
 /* Projectile pool */
 /* Bullet sprite: slot assigned at runtime via loader_get_slot(TILE_ASSET_BULLET). */
 #define MAX_PROJECTILES       8u
-#define PROJ_SPEED            4u    /* px/frame; intentionally faster than gear 1 max speed */
+#define PROJ_SPEED            4u    /* px/frame magnitude — used in PROJ_VEL_DX/DY tables in projectile.c */
 #define PROJ_MAX_TTL          60u   /* max frames alive; safety cap (~full-screen diagonal at PROJ_SPEED=4) */
 #define PROJ_FIRE_COOLDOWN    8u    /* frames between shots (held Select = 60/8 = ~7.5 shots/sec) */
 

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -31,7 +31,7 @@ static void _spawn_at(uint8_t i, uint8_t tx, uint8_t ty, uint8_t type, uint8_t d
     enemy_dir[i]    = dir;
     enemy_hp[i]     = TURRET_HP;
     enemy_active[i] = 1u;
-    enemy_timer[i]  = 0u;
+    enemy_timer[i]  = TURRET_WIND_UP;
     enemy_oam_x[i]  = (uint8_t)((uint16_t)tx * 8u + 8u);  /* OAM x cached once */
     enemy_oam[i]    = get_sprite();
     if (enemy_oam[i] != SPRITE_POOL_INVALID) {
@@ -109,13 +109,19 @@ void enemy_update(int16_t player_px, int16_t player_py) BANKED {
     uint8_t player_oam_y = (uint8_t)((int16_t)player_py - (int16_t)cam_y + 24);
 
     for (i = 0u; i < MAX_ENEMIES; i++) {
+        int16_t vis_x, vis_y;
         uint8_t scr_x, scr_y;
         if (!enemy_active[i]) continue;
 
-        /* OAM-space position of this turret — used for fire + hit detection.
-         * scr_x cached in enemy_oam_x[]; scr_y recalculated each frame (cam_y moves). */
-        scr_x = enemy_oam_x[i];
-        scr_y = (uint8_t)((int16_t)((uint16_t)enemy_ty[i] * 8u) - (int16_t)cam_y + 16);
+        /* OAM-space position — adjusted for both scroll axes */
+        vis_x = (int16_t)enemy_oam_x[i] - (int16_t)cam_x;
+        vis_y = (int16_t)((uint16_t)enemy_ty[i] * 8u) - (int16_t)cam_y + 16;
+
+        /* Skip hit detection, timer, and fire for off-screen turrets */
+        if (vis_x < 0 || vis_x >= 168 || vis_y < 0 || vis_y >= 160) continue;
+
+        scr_x = (uint8_t)vis_x;
+        scr_y = (uint8_t)vis_y;
 
         /* Check if a player bullet hit this turret */
         if (projectile_check_hit_enemy(scr_x, scr_y, TURRET_HIT_RADIUS)) {
@@ -130,7 +136,7 @@ void enemy_update(int16_t player_px, int16_t player_py) BANKED {
             }
         }
 
-        /* Fire timer */
+        /* Fire timer — only runs when turret is on screen */
         if (enemy_timer[i] > 0u) {
             enemy_timer[i]--;
         } else {
@@ -150,12 +156,12 @@ void enemy_update(int16_t player_px, int16_t player_py) BANKED {
 void enemy_render(void) BANKED {
     uint8_t i;
     for (i = 0u; i < MAX_ENEMIES; i++) {
-        int16_t oam_y;
+        int16_t oam_x_s, oam_y;
         if (!enemy_active[i] || enemy_oam[i] == SPRITE_POOL_INVALID) continue;
-        /* Turret OAM y accounts for camera scroll — turrets are in world space */
-        oam_y = (int16_t)((uint16_t)enemy_ty[i] * 8u) - (int16_t)cam_y + 16;
-        if (oam_y < 0 || oam_y > 175) continue;   /* off screen — skip */
-        move_sprite(enemy_oam[i], enemy_oam_x[i], (uint8_t)oam_y);
+        oam_y   = (int16_t)((uint16_t)enemy_ty[i] * 8u) - (int16_t)cam_y + 16;
+        oam_x_s = (int16_t)enemy_oam_x[i] - (int16_t)cam_x;
+        if (oam_y < 0 || oam_y > 175 || oam_x_s < 0 || oam_x_s > 167) continue;
+        move_sprite(enemy_oam[i], (uint8_t)oam_x_s, (uint8_t)oam_y);
     }
 }
 
@@ -181,4 +187,9 @@ uint8_t enemy_count_active(void) BANKED {
 uint8_t enemy_get_type(uint8_t i)  { return enemy_type[i]; }
 uint8_t enemy_get_dir(uint8_t i)   { return enemy_dir[i]; }
 uint8_t enemy_get_timer(uint8_t i) { return enemy_timer[i]; }
+uint8_t enemy_is_screen_visible(uint8_t i) {
+    int16_t vis_x = (int16_t)enemy_oam_x[i] - (int16_t)cam_x;
+    int16_t vis_y = (int16_t)((uint16_t)enemy_ty[i] * 8u) - (int16_t)cam_y + 16;
+    return (vis_x >= 0 && vis_x < 168 && vis_y >= 0 && vis_y < 160) ? 1u : 0u;
+}
 #endif

--- a/src/enemy.c
+++ b/src/enemy.c
@@ -83,32 +83,22 @@ player_dir_t enemy_dir_to_pixel(uint8_t tx, uint8_t ty,
     int16_t dy = player_py - (int16_t)((uint16_t)ty * 8u);
     int16_t ax = dx < 0 ? -dx : dx;
     int16_t ay = dy < 0 ? -dy : dy;
+    uint8_t toward_x;
 
-    /* Diagonal threshold: |dx| and |dy| within 2x of each other.
-     * Use << 1 instead of * 2 — SM83 has no hardware multiply. */
+    /* Threshold 1: cardinal E/W — |dx| > 2*|dy| */
     if (ax > (int16_t)(ay << 1)) {
         return dx > 0 ? DIR_R : DIR_L;
     }
+    /* Threshold 2: cardinal N/S — |dy| > 2*|dx| */
     if (ay > (int16_t)(ax << 1)) {
         return dy > 0 ? DIR_B : DIR_T;
     }
-    /* Diagonal */
-    if (dx >= 0 && dy >= 0) return DIR_RB;
-    if (dx >= 0 && dy <  0) return DIR_RT;
-    if (dx <  0 && dy >= 0) return DIR_LB;
-    return DIR_LT;
-}
-
-/* Decrement fire timers by 1 frame.
- * WARNING: do NOT call in the same frame as enemy_update() — both decrement
- * enemy_timer[], which would halve TURRET_FIRE_INTERVAL. Test helper only. */
-void enemy_tick_timers(void) BANKED {
-    uint8_t i;
-    for (i = 0u; i < MAX_ENEMIES; i++) {
-        if (enemy_active[i] && enemy_timer[i] > 0u) {
-            enemy_timer[i]--;
-        }
-    }
+    /* Threshold 3: intermediate sector — |dx| vs |dy| */
+    toward_x = (uint8_t)(ax > ay);
+    if (dx >= 0 && dy < 0) { return toward_x ? DIR_ENE : DIR_NNE; }
+    if (dx >= 0)            { return toward_x ? DIR_ESE : DIR_SSE; }
+    if (dy >= 0)            { return toward_x ? DIR_WSW : DIR_SSW; }
+    return toward_x ? DIR_WNW : DIR_NNW;
 }
 
 void enemy_update(int16_t player_px, int16_t player_py) BANKED {

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -33,7 +33,6 @@ uint8_t enemy_count_active(void) BANKED;
 /* Pure-logic helpers exposed for testing — not for production callers. */
 player_dir_t enemy_dir_to_pixel(uint8_t tx, uint8_t ty,
                                  int16_t player_px, int16_t player_py) BANKED;
-void         enemy_tick_timers(void) BANKED;
 
 /* Test-only accessors — do not call from production code */
 #ifndef __SDCC

--- a/src/enemy.h
+++ b/src/enemy.h
@@ -39,6 +39,7 @@ player_dir_t enemy_dir_to_pixel(uint8_t tx, uint8_t ty,
 uint8_t enemy_get_type(uint8_t i);
 uint8_t enemy_get_dir(uint8_t i);
 uint8_t enemy_get_timer(uint8_t i);
+uint8_t enemy_is_screen_visible(uint8_t i);
 #endif
 
 #endif /* ENEMY_H */

--- a/src/player.h
+++ b/src/player.h
@@ -4,17 +4,28 @@
 #include <gb/gb.h>
 #include <stdint.h>
 
-/* 8 facing directions — decoded from D-pad combos each frame.
- * Enum values are indices into DIR_DX / DIR_DY lookup tables. */
+/* 16 facing directions.
+ * Values 0-7: player-usable (decoded from D-pad).
+ * Values 8-15: turret-only intermediate directions (22.5° steps).
+ * All values are indices into PROJ_VEL_DX/DY tables in projectile.c. */
 typedef enum {
-    DIR_T  = 0,  /* North      (UP)           */
-    DIR_RT = 1,  /* NE         (UP + RIGHT)   */
-    DIR_R  = 2,  /* East       (RIGHT)        */
-    DIR_RB = 3,  /* SE         (DOWN + RIGHT) */
-    DIR_B  = 4,  /* South      (DOWN)         */
-    DIR_LB = 5,  /* SW         (DOWN + LEFT)  */
-    DIR_L  = 6,  /* West       (LEFT)         */
-    DIR_LT = 7,  /* NW         (UP + LEFT)    */
+    DIR_T   = 0,   /* North       (UP)           */
+    DIR_RT  = 1,   /* NE 45°      (UP + RIGHT)   */
+    DIR_R   = 2,   /* East        (RIGHT)        */
+    DIR_RB  = 3,   /* SE 45°      (DOWN + RIGHT) */
+    DIR_B   = 4,   /* South       (DOWN)         */
+    DIR_LB  = 5,   /* SW 45°      (DOWN + LEFT)  */
+    DIR_L   = 6,   /* West        (LEFT)         */
+    DIR_LT  = 7,   /* NW 45°      (UP + LEFT)    */
+    /* Turret-only intermediate directions (22.5° steps) */
+    DIR_NNE = 8,   /* N-NE 22.5°  */
+    DIR_ENE = 9,   /* E-NE 67.5°  */
+    DIR_ESE = 10,  /* E-SE 112.5° */
+    DIR_SSE = 11,  /* S-SE 157.5° */
+    DIR_SSW = 12,  /* S-SW 202.5° */
+    DIR_WSW = 13,  /* W-SW 247.5° */
+    DIR_WNW = 14,  /* W-NW 292.5° */
+    DIR_NNW = 15,  /* N-NW 337.5° */
 } player_dir_t;
 
 void     player_init(uint8_t tile_base) BANKED;

--- a/src/projectile.c
+++ b/src/projectile.c
@@ -10,6 +10,47 @@
 #include "sfx.h"  /* sfx_play is NONBANKED (bank 0) — safe to call from any bank */
 BANKREF(projectile)
 
+/* ── Direction velocity tables ──────────────────────────────────────────── */
+/* Maps player_dir_t (0-15) to bullet pixel velocity per frame.
+ * Entries 0-7 match PROJ_SPEED * DIR_DX/DY (player directions, unchanged).
+ * Entries 8-15 are turret-only intermediate directions at 22.5° steps. */
+static const int8_t PROJ_VEL_DX[16] = {
+    /*  0 DIR_T   */  0,
+    /*  1 DIR_RT  */  4,
+    /*  2 DIR_R   */  4,
+    /*  3 DIR_RB  */  4,
+    /*  4 DIR_B   */  0,
+    /*  5 DIR_LB  */ -4,
+    /*  6 DIR_L   */ -4,
+    /*  7 DIR_LT  */ -4,
+    /*  8 DIR_NNE */  2,
+    /*  9 DIR_ENE */  4,
+    /* 10 DIR_ESE */  4,
+    /* 11 DIR_SSE */  2,
+    /* 12 DIR_SSW */ -2,
+    /* 13 DIR_WSW */ -4,
+    /* 14 DIR_WNW */ -4,
+    /* 15 DIR_NNW */ -2,
+};
+static const int8_t PROJ_VEL_DY[16] = {
+    /*  0 DIR_T   */ -4,
+    /*  1 DIR_RT  */ -4,
+    /*  2 DIR_R   */  0,
+    /*  3 DIR_RB  */  4,
+    /*  4 DIR_B   */  4,
+    /*  5 DIR_LB  */  4,
+    /*  6 DIR_L   */  0,
+    /*  7 DIR_LT  */ -4,
+    /*  8 DIR_NNE */ -4,
+    /*  9 DIR_ENE */ -2,
+    /* 10 DIR_ESE */  2,
+    /* 11 DIR_SSE */  4,
+    /* 12 DIR_SSW */  4,
+    /* 13 DIR_WSW */  2,
+    /* 14 DIR_WNW */ -2,
+    /* 15 DIR_NNW */ -4,
+};
+
 /* ── SoA bullet pool ───────────────────────────────────────────────────── */
 static uint8_t proj_x[MAX_PROJECTILES];
 static uint8_t proj_y[MAX_PROJECTILES];
@@ -53,8 +94,8 @@ void projectile_fire(uint8_t scr_x, uint8_t scr_y, player_dir_t dir, uint8_t own
 
             proj_x[i]      = scr_x;
             proj_y[i]      = scr_y;
-            proj_dx[i]     = (int8_t)((int8_t)PROJ_SPEED * player_dir_dx(dir));
-            proj_dy[i]     = (int8_t)((int8_t)PROJ_SPEED * player_dir_dy(dir));
+            proj_dx[i]     = PROJ_VEL_DX[(uint8_t)dir];
+            proj_dy[i]     = PROJ_VEL_DY[(uint8_t)dir];
             proj_ttl[i]    = PROJ_MAX_TTL;
             proj_owner[i]  = owner;
             proj_oam[i]    = oam;

--- a/tests/test_enemy.c
+++ b/tests/test_enemy.c
@@ -41,20 +41,42 @@ void test_enemy_direction_to_player_down(void) {
     TEST_ASSERT_EQUAL_INT(DIR_B, enemy_dir_to_pixel(0u, 0u, 0, 64));
 }
 
+/* ax == ay tie → toward_x = (ax > ay) = 0 → NNE-side direction */
 void test_enemy_direction_to_player_down_right(void) {
-    TEST_ASSERT_EQUAL_INT(DIR_RB, enemy_dir_to_pixel(0u, 0u, 64, 64));
+    /* Was DIR_RB; 3-threshold: ax=ay=64, toward_x=0, SE quadrant → DIR_SSE */
+    TEST_ASSERT_EQUAL_INT(DIR_SSE, enemy_dir_to_pixel(0u, 0u, 64, 64));
 }
-
 void test_enemy_direction_to_player_up_left(void) {
-    TEST_ASSERT_EQUAL_INT(DIR_LT, enemy_dir_to_pixel(10u, 10u, 0, 0));
-    /* turret pixel = (80, 80); player at (0,0): dx=-80, dy=-80 → DIR_LT */
+    /* Was DIR_LT; 3-threshold: ax=ay=80, toward_x=0, NW quadrant → DIR_NNW */
+    TEST_ASSERT_EQUAL_INT(DIR_NNW, enemy_dir_to_pixel(10u, 10u, 0, 0));
 }
 
-void test_enemy_timer_fires_on_first_frame(void) {
-    enemy_spawn(10u, 20u);
-    /* Timer starts at 0 — fires on the very first update; active count unchanged */
-    enemy_tick_timers();   /* 1 frame — timer was already 0, stays 0 until fire */
-    TEST_ASSERT_EQUAL_UINT8(1u, enemy_count_active());
+/* 16-direction tests — intermediate sectors */
+void test_enemy_direction_nne(void) {
+    /* ax=10 < ay=15, NE quadrant → DIR_NNE */
+    TEST_ASSERT_EQUAL_INT(DIR_NNE, enemy_dir_to_pixel(0u, 0u, 10, -15));
+}
+void test_enemy_direction_ene(void) {
+    /* ax=15 > ay=10, NE quadrant → DIR_ENE */
+    TEST_ASSERT_EQUAL_INT(DIR_ENE, enemy_dir_to_pixel(0u, 0u, 15, -10));
+}
+void test_enemy_direction_ese(void) {
+    TEST_ASSERT_EQUAL_INT(DIR_ESE, enemy_dir_to_pixel(0u, 0u, 15, 10));
+}
+void test_enemy_direction_sse(void) {
+    TEST_ASSERT_EQUAL_INT(DIR_SSE, enemy_dir_to_pixel(0u, 0u, 10, 15));
+}
+void test_enemy_direction_ssw(void) {
+    TEST_ASSERT_EQUAL_INT(DIR_SSW, enemy_dir_to_pixel(0u, 0u, -10, 15));
+}
+void test_enemy_direction_wsw(void) {
+    TEST_ASSERT_EQUAL_INT(DIR_WSW, enemy_dir_to_pixel(0u, 0u, -15, 10));
+}
+void test_enemy_direction_wnw(void) {
+    TEST_ASSERT_EQUAL_INT(DIR_WNW, enemy_dir_to_pixel(0u, 0u, -15, -10));
+}
+void test_enemy_direction_nnw(void) {
+    TEST_ASSERT_EQUAL_INT(DIR_NNW, enemy_dir_to_pixel(0u, 0u, -10, -15));
 }
 
 void test_enemy_timer_zero_at_spawn(void) {
@@ -118,7 +140,14 @@ int main(void) {
     RUN_TEST(test_enemy_direction_to_player_down);
     RUN_TEST(test_enemy_direction_to_player_down_right);
     RUN_TEST(test_enemy_direction_to_player_up_left);
-    RUN_TEST(test_enemy_timer_fires_on_first_frame);
+    RUN_TEST(test_enemy_direction_nne);
+    RUN_TEST(test_enemy_direction_ene);
+    RUN_TEST(test_enemy_direction_ese);
+    RUN_TEST(test_enemy_direction_sse);
+    RUN_TEST(test_enemy_direction_ssw);
+    RUN_TEST(test_enemy_direction_wsw);
+    RUN_TEST(test_enemy_direction_wnw);
+    RUN_TEST(test_enemy_direction_nnw);
     RUN_TEST(test_enemy_timer_zero_at_spawn);
     RUN_TEST(test_enemy_three_turrets_timer_all_zero);
     RUN_TEST(test_enemy_spawn_sets_type_turret);

--- a/tests/test_enemy.c
+++ b/tests/test_enemy.c
@@ -81,12 +81,29 @@ void test_enemy_spawn_sets_dir_none(void) {
     TEST_ASSERT_EQUAL_UINT8(DIR_NONE, enemy_get_dir(0u));
 }
 
+void test_turret_dir_enum_has_16_values(void) {
+    /* Compile-time check: new enum constants exist and are in range 8-15 */
+    TEST_ASSERT_EQUAL_INT(8,  DIR_NNE);
+    TEST_ASSERT_EQUAL_INT(9,  DIR_ENE);
+    TEST_ASSERT_EQUAL_INT(10, DIR_ESE);
+    TEST_ASSERT_EQUAL_INT(11, DIR_SSE);
+    TEST_ASSERT_EQUAL_INT(12, DIR_SSW);
+    TEST_ASSERT_EQUAL_INT(13, DIR_WSW);
+    TEST_ASSERT_EQUAL_INT(14, DIR_WNW);
+    TEST_ASSERT_EQUAL_INT(15, DIR_NNW);
+}
+
 void test_npc_type_constants_defined(void) {
     /* Compile-time presence; verify values match tmx_to_c.py NPC_TYPE_MAP */
     TEST_ASSERT_EQUAL_UINT8(0u, NPC_TYPE_TURRET);
     TEST_ASSERT_EQUAL_UINT8(1u, NPC_TYPE_CAR);
     TEST_ASSERT_EQUAL_UINT8(2u, NPC_TYPE_PEDESTRIAN);
     TEST_ASSERT_EQUAL_UINT8(0xFFu, DIR_NONE);
+}
+
+void test_turret_constants_values(void) {
+    TEST_ASSERT_EQUAL_UINT8(45u, TURRET_FIRE_INTERVAL);
+    TEST_ASSERT_EQUAL_UINT8(30u, TURRET_WIND_UP);
 }
 
 int main(void) {
@@ -106,5 +123,7 @@ int main(void) {
     RUN_TEST(test_enemy_three_turrets_timer_all_zero);
     RUN_TEST(test_enemy_spawn_sets_type_turret);
     RUN_TEST(test_enemy_spawn_sets_dir_none);
+    RUN_TEST(test_turret_dir_enum_has_16_values);
+    RUN_TEST(test_turret_constants_values);
     return UNITY_END();
 }

--- a/tests/test_enemy.c
+++ b/tests/test_enemy.c
@@ -1,6 +1,7 @@
 #include "unity.h"
 #include "enemy.h"
 #include "player.h"   /* player_dir_t */
+#include "camera.h"   /* cam_x, cam_y */
 
 void setUp(void) { enemy_init_empty(); }
 void tearDown(void) {}
@@ -79,18 +80,58 @@ void test_enemy_direction_nnw(void) {
     TEST_ASSERT_EQUAL_INT(DIR_NNW, enemy_dir_to_pixel(0u, 0u, -10, -15));
 }
 
-void test_enemy_timer_zero_at_spawn(void) {
+void test_enemy_spawn_timer_is_wind_up(void) {
     enemy_spawn(10u, 20u);
-    TEST_ASSERT_EQUAL_UINT8(0u, enemy_get_timer(0u));
+    TEST_ASSERT_EQUAL_UINT8(TURRET_WIND_UP, enemy_get_timer(0u));
 }
 
-void test_enemy_three_turrets_timer_all_zero(void) {
+void test_enemy_three_turrets_timer_at_wind_up(void) {
     enemy_spawn(4u, 22u);
     enemy_spawn(15u, 47u);
     enemy_spawn(5u, 72u);
-    TEST_ASSERT_EQUAL_UINT8(0u, enemy_get_timer(0u));
-    TEST_ASSERT_EQUAL_UINT8(0u, enemy_get_timer(1u));
-    TEST_ASSERT_EQUAL_UINT8(0u, enemy_get_timer(2u));
+    TEST_ASSERT_EQUAL_UINT8(TURRET_WIND_UP, enemy_get_timer(0u));
+    TEST_ASSERT_EQUAL_UINT8(TURRET_WIND_UP, enemy_get_timer(1u));
+    TEST_ASSERT_EQUAL_UINT8(TURRET_WIND_UP, enemy_get_timer(2u));
+}
+
+void test_enemy_timer_does_not_fire_during_wind_up(void) {
+    enemy_spawn(10u, 20u);
+    TEST_ASSERT_EQUAL_UINT8(TURRET_WIND_UP, enemy_get_timer(0u));
+    TEST_ASSERT_EQUAL_UINT8(1u, enemy_count_active());
+}
+
+/* Visibility helper tests — set cam_x/cam_y directly */
+void test_enemy_visible_when_on_screen(void) {
+    /* ty=10: world_y=80. cam_y=0 → vis_y=80-0+16=96 ∈ [0,160) ✓
+     * tx=10: world_oam_x=88. cam_x=0 → vis_x=88 ∈ [0,168) ✓ */
+    cam_y = 0u;
+    cam_x = 0u;
+    enemy_spawn(10u, 10u);
+    TEST_ASSERT_EQUAL_UINT8(1u, enemy_is_screen_visible(0u));
+}
+
+void test_enemy_not_visible_when_below_screen(void) {
+    /* ty=20: world_y=160. cam_y=0 → vis_y=160-0+16=176 ≥ 160 → off screen */
+    cam_y = 0u;
+    cam_x = 0u;
+    enemy_spawn(10u, 20u);
+    TEST_ASSERT_EQUAL_UINT8(0u, enemy_is_screen_visible(0u));
+}
+
+void test_enemy_not_visible_when_above_screen(void) {
+    /* ty=1: world_y=8. cam_y=100 → vis_y=8-100+16=-76 < 0 → off screen */
+    cam_y = 100u;
+    cam_x = 0u;
+    enemy_spawn(10u, 1u);
+    TEST_ASSERT_EQUAL_UINT8(0u, enemy_is_screen_visible(0u));
+}
+
+void test_enemy_not_visible_when_off_screen_right(void) {
+    /* tx=22: oam_x=22*8+8=184. cam_x=0 → vis_x=184 ≥ 168 → off screen */
+    cam_y = 0u;
+    cam_x = 0u;
+    enemy_spawn(22u, 10u);
+    TEST_ASSERT_EQUAL_UINT8(0u, enemy_is_screen_visible(0u));
 }
 
 void test_enemy_spawn_sets_type_turret(void) {
@@ -148,8 +189,13 @@ int main(void) {
     RUN_TEST(test_enemy_direction_wsw);
     RUN_TEST(test_enemy_direction_wnw);
     RUN_TEST(test_enemy_direction_nnw);
-    RUN_TEST(test_enemy_timer_zero_at_spawn);
-    RUN_TEST(test_enemy_three_turrets_timer_all_zero);
+    RUN_TEST(test_enemy_spawn_timer_is_wind_up);
+    RUN_TEST(test_enemy_three_turrets_timer_at_wind_up);
+    RUN_TEST(test_enemy_timer_does_not_fire_during_wind_up);
+    RUN_TEST(test_enemy_visible_when_on_screen);
+    RUN_TEST(test_enemy_not_visible_when_below_screen);
+    RUN_TEST(test_enemy_not_visible_when_above_screen);
+    RUN_TEST(test_enemy_not_visible_when_off_screen_right);
     RUN_TEST(test_enemy_spawn_sets_type_turret);
     RUN_TEST(test_enemy_spawn_sets_dir_none);
     RUN_TEST(test_turret_dir_enum_has_16_values);


### PR DESCRIPTION
## Summary
- Replace 8-direction snap-fire with 16-direction aim using a 3-threshold integer comparison in `enemy_dir_to_pixel` (no division, no LUTs)
- Add `PROJ_VEL_DX/DY[16]` velocity tables in `projectile.c`, removing the `PROJ_SPEED * player_dir_dx/dy` BANKED multiply
- Add 30-frame wind-up timer on first screen appearance and screen-visibility gate — turrets skip hit-detection, timer, and fire entirely while off-screen; `TURRET_FIRE_INTERVAL` reduced from 60 to 45 frames (~0.75 s)
- Fix `cam_x` not being subtracted from turret screen-x in both `enemy_update` and `enemy_render`

## Test Plan
- [x] `make test` passes (466 tests, 0 failures)
- [x] All 3 Emulicious smoketests confirmed by user (Checkpoints 1, 2, 3)
- [x] bank-post-build gates passed (WARN on ROM_0/ROM_1 are pre-existing)
- [x] gb-memory-validator: WRAM 13%, VRAM 16%, OAM 77% — all PASS
- [x] AC1: turrets off-screen fire no bullets
- [x] AC2: ~0.5 s wind-up delay on first appearance
- [x] AC3: timer resumes after scrolling back, no re-wind-up
- [x] AC4: bullet trajectories at 22.5°/67.5° angles
- [x] AC5: faster fire cadence (~0.75 s)
- [x] AC6: player bullets, movement, all other systems unchanged

Closes #353