### PR TITLE
fix(state_playing): hide player sprite on exit (issue #323)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -396,7 +396,8 @@
       "Bash(timeout 5 ./build/test_terrain_physics)",
       "Bash(timeout 5 ./build/test_track)",
       "Bash(timeout 5 ./build/test_track_dispatch)",
-      "Bash(./build/test_player)"
+      "Bash(./build/test_player)",
+      "Bash(awk '{fail+=$3} END {print \"Total failures:\", fail}')"
     ]
   },
   "hooks": {

--- a/src/player.c
+++ b/src/player.c
@@ -243,6 +243,13 @@ void player_reset_vel(void) BANKED {
     downshift_timer = 0u;
 }
 
+void player_hide(void) BANKED {
+    move_sprite(player_sprite_slot[0], 0u, 0u);
+    move_sprite(player_sprite_slot[1], 0u, 0u);
+    move_sprite(player_sprite_slot[2], 0u, 0u);
+    move_sprite(player_sprite_slot[3], 0u, 0u);
+}
+
 static player_dir_t decode_dir(uint8_t buttons) {
     if ((buttons & J_UP)   && (buttons & J_RIGHT)) return DIR_RT;
     if ((buttons & J_DOWN) && (buttons & J_RIGHT)) return DIR_RB;

--- a/src/player.h
+++ b/src/player.h
@@ -40,6 +40,7 @@ int8_t   player_get_vy(void) BANKED;
 #include "track.h"
 
 void player_reset_vel(void) BANKED;
+void player_hide(void) BANKED;
 void player_apply_physics(uint8_t buttons, TileType terrain) BANKED;
 player_dir_t player_get_dir(void) BANKED;
 void player_set_dir(player_dir_t dir) BANKED;

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -215,6 +215,7 @@ static void update(void) {
 }
 
 static void sp_exit(void) {
+    player_hide();
     loader_unload_state();
     HIDE_WIN;
     cam_scx_shadow = 0u;

--- a/tests/test_player.c
+++ b/tests/test_player.c
@@ -522,6 +522,24 @@ void test_hitbox_cardinal_damage_on_collision(void) {
     TEST_ASSERT_EQUAL_UINT8(hp_before - 1u, damage_get_hp());
 }
 
+/* ===== player_hide (issue #323) =========================================== */
+
+void test_player_hide_moves_all_sprites_off_screen(void) {
+    /* Position sprites at visible coords first */
+    player_render();
+    /* Verify at least one slot is non-zero before hiding */
+    TEST_ASSERT_NOT_EQUAL(0, mock_sprite_y[0]);
+    player_hide();
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_x[0]);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_y[0]);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_x[1]);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_y[1]);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_x[2]);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_y[2]);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_x[3]);
+    TEST_ASSERT_EQUAL_UINT8(0u, mock_sprite_y[3]);
+}
+
 /* ===== player_set_dir setter (issue #358) ================================= */
 
 void test_player_set_dir_north(void) {
@@ -608,6 +626,8 @@ int main(void) {
     RUN_TEST(test_hitbox_cardinal_wall_blocks);
     RUN_TEST(test_hitbox_diagonal_along_wall_passes);
     RUN_TEST(test_hitbox_cardinal_damage_on_collision);
+    /* AC: player_hide (issue #323) */
+    RUN_TEST(test_player_hide_moves_all_sprites_off_screen);
     /* AC: player_set_dir setter */
     RUN_TEST(test_player_set_dir_north);
     RUN_TEST(test_player_set_dir_south);


### PR DESCRIPTION
## Summary

- Added `player_hide()` to `src/player.c`/`src/player.h` — moves all 4 OAM slots to (0,0)
- Called as the first statement in `sp_exit()` in `src/state_playing.c`, before `loader_unload_state()`, so OAM is cleared before tile slots can be reused by the next state
- Covers all three exit paths from STATE_PLAYING: race win, combat win, and player death

## Test Plan

- [x] `make test` passes — new test `test_player_hide_moves_all_sprites_off_screen` verifies all 4 OAM slots are zeroed after `player_hide()`
- [x] Emulicious smoketest confirmed: results/win screen and game-over screen show no player sprite; in-race rendering is unchanged
- [x] `bank-post-build` gates passed (WARNs pre-existing)
- [x] `gb-memory-validator`: WRAM 13%, VRAM 16%, OAM 77% — all PASS

Closes #323