### PR TITLE
fix(racer): spawn position, lap count, direction, sprite, wall collision, end screen

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -406,7 +406,8 @@
       "Skill(gb-memory-validator)",
       "Skill(bank-pre-write)",
       "Bash(timeout 10 ./build/test_racer *)",
-      "Skill(systematic-debugging)"
+      "Skill(systematic-debugging)",
+      "Skill(track-build)"
     ]
   },
   "hooks": {

--- a/assets/maps/track2.tmx
+++ b/assets/maps/track2.tmx
@@ -139,7 +139,7 @@
   </object>
  </objectgroup>
  <objectgroup id="5" name="enemies">
-  <object id="5" name="car" x="104" y="112"/>
+  <object id="5" name="car" x="112" y="40"/>
  </objectgroup>
  <objectgroup id="6" name="racer_waypoints">
   <object id="6" x="104" y="48"><point/></object>

--- a/assets/maps/track2.tmx
+++ b/assets/maps/track2.tmx
@@ -142,17 +142,41 @@
   <object id="5" name="car" x="112" y="40"/>
  </objectgroup>
  <objectgroup id="6" name="racer_waypoints">
-  <object id="6" x="104" y="48"><point/></object>
-  <object id="7" x="104" y="160"><point/></object>
-  <object id="8" x="104" y="320"><point/></object>
-  <object id="9" x="104" y="480"><point/></object>
-  <object id="10" x="104" y="640"><point/></object>
-  <object id="11" x="104" y="760"><point/></object>
-  <object id="12" x="48" y="776"><point/></object>
-  <object id="13" x="40" y="640"><point/></object>
-  <object id="14" x="40" y="480"><point/></object>
-  <object id="15" x="40" y="320"><point/></object>
-  <object id="16" x="40" y="160"><point/></object>
-  <object id="17" x="40" y="16"><point/></object>
+  <object id="6" x="112" y="40">
+   <point/>
+  </object>
+  <object id="7" x="104" y="160">
+   <point/>
+  </object>
+  <object id="8" x="104" y="320">
+   <point/>
+  </object>
+  <object id="9" x="104" y="480">
+   <point/>
+  </object>
+  <object id="10" x="104" y="640">
+   <point/>
+  </object>
+  <object id="11" x="104" y="760">
+   <point/>
+  </object>
+  <object id="12" x="48" y="776">
+   <point/>
+  </object>
+  <object id="13" x="40" y="640">
+   <point/>
+  </object>
+  <object id="14" x="40" y="480">
+   <point/>
+  </object>
+  <object id="15" x="40" y="320">
+   <point/>
+  </object>
+  <object id="16" x="40" y="160">
+   <point/>
+  </object>
+  <object id="17" x="40" y="16">
+   <point/>
+  </object>
  </objectgroup>
 </map>

--- a/src/racer.c
+++ b/src/racer.c
@@ -179,6 +179,16 @@ void racer_init_empty(void) BANKED {
     s_lap_total = 1u;
 }
 
+void racer_hide(void) BANKED {
+    uint8_t i;
+    uint8_t j;
+    for (i = 0u; i < MAX_RACERS; i++) {
+        for (j = 0u; j < 4u; j++) {
+            move_sprite(racer_oam[i * 4u + j], 0u, 0u);
+        }
+    }
+}
+
 uint8_t racer_update(void) BANKED {
     uint8_t i;
     for (i = 0u; i < MAX_RACERS; i++) {
@@ -238,8 +248,14 @@ uint8_t racer_update(void) BANKED {
             }
         }
 
-        racer_px[i] += (int16_t)RACER_DIR_DX[dir] * (int16_t)RACER_SPEED;
-        racer_py[i] += (int16_t)RACER_DIR_DY[dir] * (int16_t)RACER_SPEED;
+        {
+            int16_t new_px = racer_px[i] + (int16_t)RACER_DIR_DX[dir] * (int16_t)RACER_SPEED;
+            int16_t new_py = racer_py[i] + (int16_t)RACER_DIR_DY[dir] * (int16_t)RACER_SPEED;
+            if (track_passable(new_px, new_py)) {
+                racer_px[i] = new_px;
+                racer_py[i] = new_py;
+            }
+        }
     }
     return 0u;
 }

--- a/src/racer.c
+++ b/src/racer.c
@@ -285,14 +285,14 @@ void racer_render(void) BANKED {
             uint8_t cgb_flags = flags | S_PAL(1u);
             set_sprite_prop(racer_oam[i * 4u + 0u], cgb_flags);
             set_sprite_prop(racer_oam[i * 4u + 1u], cgb_flags);
-            set_sprite_prop(racer_oam[i * 4u + 2u], (uint8_t)(cgb_flags | S_FLIPY));
-            set_sprite_prop(racer_oam[i * 4u + 3u], (uint8_t)(cgb_flags | S_FLIPY));
+            set_sprite_prop(racer_oam[i * 4u + 2u], cgb_flags);
+            set_sprite_prop(racer_oam[i * 4u + 3u], cgb_flags);
         }
 #else
         set_sprite_prop(racer_oam[i * 4u + 0u], flags);
         set_sprite_prop(racer_oam[i * 4u + 1u], flags);
-        set_sprite_prop(racer_oam[i * 4u + 2u], (uint8_t)(flags | S_FLIPY));
-        set_sprite_prop(racer_oam[i * 4u + 3u], (uint8_t)(flags | S_FLIPY));
+        set_sprite_prop(racer_oam[i * 4u + 2u], flags);
+        set_sprite_prop(racer_oam[i * 4u + 3u], flags);
 #endif /* __SDCC */
 
         move_sprite(racer_oam[i * 4u + 0u], hw_x,            hw_y);

--- a/src/racer.c
+++ b/src/racer.c
@@ -28,7 +28,8 @@ static uint8_t  s_wp_ty[MAX_RACER_WAYPOINTS];
 static uint8_t  s_wp_count;
 static uint8_t  s_finish_dir;
 static uint8_t  s_tile_base;
-static uint8_t  s_laps_done;  /* must complete 1 full wp cycle before finish can trigger */
+static uint8_t  s_laps_done;  /* completed wp cycles so far */
+static uint8_t  s_lap_total;  /* number of full wp cycles required to win */
 
 /* ---- Direction tables — copied from player.c exact values ---- */
 
@@ -139,6 +140,7 @@ void racer_init(uint8_t tile_base) BANKED {
 
     track_id = track_get_id();
     s_finish_dir = track_get_finish_direction();
+    s_lap_total  = track_get_lap_count();
     load_racer_waypoints(track_id, s_wp_tx, s_wp_ty, &s_wp_count);
     found = load_racer_spawn(track_id, &spawn_tx, &spawn_ty);
 
@@ -147,7 +149,7 @@ void racer_init(uint8_t tile_base) BANKED {
         racer_px[0] = (int16_t)((uint16_t)spawn_tx * 8u + 4u);
         racer_py[0] = (int16_t)((uint16_t)spawn_ty * 8u + 4u);
         racer_wp_idx[0] = 0u;
-        racer_dir[0] = DIR_T;
+        racer_dir[0] = track_get_start_dir();
         for (i = 0u; i < 4u; i++) {
             racer_oam[i] = get_sprite();
         }
@@ -229,7 +231,7 @@ uint8_t racer_update(void) BANKED {
         ty = (uint8_t)((uint16_t)racer_py[i] >> 3u);
         raw_tile  = track_get_raw_tile(tx, ty);
         tile_type = track_tile_type_from_index(raw_tile);
-        if (s_laps_done > 0u && tile_type == TILE_FINISH) {
+        if (s_laps_done >= s_lap_total && tile_type == TILE_FINISH) {
             if (racer_dir_matches_finish(dir, s_finish_dir)) {
                 return 1u;
             }
@@ -303,7 +305,8 @@ void racer_render(void) BANKED {
 
 void racer_spawn_for_test(int16_t px, int16_t py,
                            uint8_t *wp_tx, uint8_t *wp_ty,
-                           uint8_t wp_count, uint8_t finish_dir) {
+                           uint8_t wp_count, uint8_t finish_dir,
+                           uint8_t lap_total) {
     uint8_t i;
     for (i = 0u; i < MAX_RACERS; i++) racer_active[i] = 0u;
     racer_active[0] = 1u;
@@ -318,7 +321,12 @@ void racer_spawn_for_test(int16_t px, int16_t py,
     }
     s_wp_count   = wp_count;
     s_finish_dir = finish_dir;
-    s_laps_done  = 1u;
+    s_lap_total  = lap_total;
+    s_laps_done  = lap_total;  /* ready to trigger finish detection */
+}
+
+void racer_set_laps_done_for_test(uint8_t n) {
+    s_laps_done = n;
 }
 
 void racer_place_on_finish_for_test(uint8_t tx, uint8_t ty, uint8_t dir) {

--- a/src/racer.c
+++ b/src/racer.c
@@ -176,6 +176,7 @@ void racer_init_empty(void) BANKED {
     }
     s_wp_count  = 0u;
     s_laps_done = 0u;
+    s_lap_total = 1u;
 }
 
 uint8_t racer_update(void) BANKED {

--- a/src/racer.h
+++ b/src/racer.h
@@ -12,7 +12,9 @@ void    racer_render(void) BANKED;
 #ifndef __SDCC
 void    racer_spawn_for_test(int16_t px, int16_t py,
                               uint8_t *wp_tx, uint8_t *wp_ty,
-                              uint8_t wp_count, uint8_t finish_dir);
+                              uint8_t wp_count, uint8_t finish_dir,
+                              uint8_t lap_total);
+void    racer_set_laps_done_for_test(uint8_t n);
 void    racer_place_on_finish_for_test(uint8_t tx, uint8_t ty, uint8_t dir);
 void    racer_set_wp_idx_for_test(uint8_t slot, uint8_t idx);
 void    racer_set_pos_for_test(uint8_t slot, int16_t px, int16_t py);

--- a/src/racer.h
+++ b/src/racer.h
@@ -6,6 +6,7 @@
 
 void    racer_init(uint8_t tile_base) BANKED;
 void    racer_init_empty(void) BANKED;
+void    racer_hide(void) BANKED;
 uint8_t racer_update(void) BANKED;
 void    racer_render(void) BANKED;
 

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -104,6 +104,7 @@ static void enter(void) {
     hud_set_lap(lap_get_current(), lap_get_total());
     camera_apply_scroll();
     player_render();
+    racer_render();
     /* Countdown init: reset phase and write initial '03' to BG tilemap. */
     cd_phase  = 0u;
     cd_frames = 0u;

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -223,6 +223,7 @@ static void update(void) {
 
 static void sp_exit(void) {
     player_hide();
+    racer_hide();
     loader_unload_state();
     HIDE_WIN;
     cam_scx_shadow = 0u;

--- a/src/track2_map.c
+++ b/src/track2_map.c
@@ -170,8 +170,8 @@ BANKREF(track2_racer_wp_count)
 const uint8_t track2_racer_wp_count = 12u;
 
 BANKREF(track2_racer_wp_tx)
-const uint8_t track2_racer_wp_tx[12] = { 13u, 13u, 13u, 13u, 13u, 13u, 6u, 5u, 5u, 5u, 5u, 5u };
+const uint8_t track2_racer_wp_tx[12] = { 14u, 13u, 13u, 13u, 13u, 13u, 6u, 5u, 5u, 5u, 5u, 5u };
 
 BANKREF(track2_racer_wp_ty)
-const uint8_t track2_racer_wp_ty[12] = { 6u, 20u, 40u, 60u, 80u, 95u, 97u, 80u, 60u, 40u, 20u, 2u };
+const uint8_t track2_racer_wp_ty[12] = { 5u, 20u, 40u, 60u, 80u, 95u, 97u, 80u, 60u, 40u, 20u, 2u };
 

--- a/src/track2_map.c
+++ b/src/track2_map.c
@@ -143,10 +143,10 @@ BANKREF(track2_npc_count)
 const uint8_t track2_npc_count = 1u;
 
 BANKREF(track2_npc_tx)
-const uint8_t track2_npc_tx[8] = { 13u, 0u, 0u, 0u, 0u, 0u, 0u, 0u };
+const uint8_t track2_npc_tx[8] = { 14u, 0u, 0u, 0u, 0u, 0u, 0u, 0u };
 
 BANKREF(track2_npc_ty)
-const uint8_t track2_npc_ty[8] = { 14u, 0u, 0u, 0u, 0u, 0u, 0u, 0u };
+const uint8_t track2_npc_ty[8] = { 5u, 0u, 0u, 0u, 0u, 0u, 0u, 0u };
 
 BANKREF(track2_npc_type)
 const uint8_t track2_npc_type[8] = { 1u, 0u, 0u, 0u, 0u, 0u, 0u, 0u };

--- a/tests/test_racer.c
+++ b/tests/test_racer.c
@@ -21,7 +21,7 @@ void test_racer_inactive_after_init_empty(void) {
 void test_racer_advances_waypoint_when_close(void) {
     uint8_t wp_tx[2] = { 10u, 20u };
     uint8_t wp_ty[2] = { 10u, 10u };
-    racer_spawn_for_test(84u, 84u, wp_tx, wp_ty, 2u, CHECKPOINT_DIR_S);
+    racer_spawn_for_test(84u, 84u, wp_tx, wp_ty, 2u, CHECKPOINT_DIR_S, 1u);
     racer_update();
     TEST_ASSERT_EQUAL_UINT8(1u, racer_get_wp_idx(0u));
 }
@@ -42,7 +42,7 @@ void test_racer_finish_triggers_game_over(void) {
     uint8_t wp_tx[1] = { 5u };
     uint8_t wp_ty[1] = { 5u };
     track_test_set_map(finish_map, 8u, 8u);
-    racer_spawn_for_test(44u, 44u, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_S);
+    racer_spawn_for_test(44u, 44u, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_S, 1u);
     racer_place_on_finish_for_test(5u, 6u, DIR_B);
     TEST_ASSERT_EQUAL_UINT8(1u, racer_update());
 }
@@ -64,7 +64,7 @@ void test_racer_finish_wrong_direction_no_game_over(void) {
     uint8_t wp_tx[1] = { 5u };
     uint8_t wp_ty[1] = { 0u };
     track_test_set_map(finish_map, 8u, 8u);
-    racer_spawn_for_test(44u, 44u, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_S);
+    racer_spawn_for_test(44u, 44u, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_S, 1u);
     /* Place racer centre at tile (5,6) = pixel (44,52), heading toward waypoint (5,0) */
     racer_set_pos_for_test(0u, 44, 52);
     TEST_ASSERT_EQUAL_UINT8(0u, racer_update());
@@ -73,11 +73,53 @@ void test_racer_finish_wrong_direction_no_game_over(void) {
 void test_racer_wraps_waypoints(void) {
     uint8_t wp_tx[2] = { 10u, 20u };
     uint8_t wp_ty[2] = { 10u, 10u };
-    racer_spawn_for_test(84u, 84u, wp_tx, wp_ty, 2u, CHECKPOINT_DIR_S);
+    racer_spawn_for_test(84u, 84u, wp_tx, wp_ty, 2u, CHECKPOINT_DIR_S, 1u);
     racer_set_wp_idx_for_test(0u, 1u);
     racer_set_pos_for_test(0u, 164, 84);
     racer_update();
     TEST_ASSERT_EQUAL_UINT8(0u, racer_get_wp_idx(0u));
+}
+
+void test_racer_no_finish_before_all_laps_done(void) {
+    /* Racer on finish tile with 2 laps done out of 3 required — must NOT trigger. */
+    static const uint8_t finish_map[8*8] = {
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,12,1,1,
+        1,1,1,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 5u };
+    uint8_t wp_ty[1] = { 5u };
+    track_test_set_map(finish_map, 8u, 8u);
+    racer_spawn_for_test(44u, 44u, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_S, 3u);
+    racer_set_laps_done_for_test(2u);  /* 2 of 3 laps done */
+    racer_place_on_finish_for_test(5u, 6u, DIR_B);
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_update());
+}
+
+void test_racer_finishes_after_all_laps_done(void) {
+    /* Racer on finish tile with exactly lap_total laps done — must trigger. */
+    static const uint8_t finish_map[8*8] = {
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,12,1,1,
+        1,1,1,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 5u };
+    uint8_t wp_ty[1] = { 5u };
+    track_test_set_map(finish_map, 8u, 8u);
+    racer_spawn_for_test(44u, 44u, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_S, 3u);
+    /* racer_spawn_for_test sets s_laps_done = lap_total = 3 */
+    racer_place_on_finish_for_test(5u, 6u, DIR_B);
+    TEST_ASSERT_EQUAL_UINT8(1u, racer_update());
 }
 
 int main(void) {
@@ -87,5 +129,7 @@ int main(void) {
     RUN_TEST(test_racer_finish_triggers_game_over);
     RUN_TEST(test_racer_finish_wrong_direction_no_game_over);
     RUN_TEST(test_racer_wraps_waypoints);
+    RUN_TEST(test_racer_no_finish_before_all_laps_done);
+    RUN_TEST(test_racer_finishes_after_all_laps_done);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- **Lap count**: racer now uses `track_get_lap_count()` for win threshold; game-over only triggers after completing all required laps (not on first finish crossing)
- **Start direction**: racer direction initialized from `track_get_start_dir()` instead of hardcoded `DIR_T`
- **Sprite fix**: apply uniform flip flags to all 4 OAM slots (was incorrectly forcing `S_FLIPY` on right-column slots, garbling diagonal frames)
- **Wall collision**: racer movement gated on `track_passable()` so enemy cannot enter hub tiles (#369 tracks upgrade to 4-corner check)
- **End screen**: `racer_hide()` called from `sp_exit()` so racer sprite disappears on results/game-over screen
- **Countdown visibility**: `racer_render()` called in `state_playing` enter() so both cars are visible during pre-race countdown
- **Spawn position**: car NPC repositioned on the start line alongside player start

Closes #361

## Test plan

- [ ] Start race on track 2 — both player and racer cars visible side-by-side during countdown
- [ ] Let racer run — diagonal sprites look correct (no garble)
- [ ] Racer cannot enter hub area
- [ ] Game-over does NOT appear after racer's first lap; appears after 3rd lap
- [ ] Racer sprite disappears on end/results screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)