### PR TITLE
fix(racer): 4-corner wall collision + gear velocity physics

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -407,7 +407,10 @@
       "Skill(bank-pre-write)",
       "Bash(timeout 10 ./build/test_racer *)",
       "Skill(systematic-debugging)",
-      "Skill(track-build)"
+      "Skill(track-build)",
+      "Bash(awk -F: '$2 ~ /static/ {print NR\": \"$0}')",
+      "Bash(awk -F: '{print $1, $2}')",
+      "Bash(awk *)"
     ]
   },
   "hooks": {

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Or load `build/nuke-raider.gb` in any GB/GBC emulator ([Emulicious](https://emul
 | SFX | `src/sfx.c/.h` | One-shot sound effects: CH4 noise (SFX_SHOOT, SFX_HIT) and CH1 tone sweep (SFX_HEAL, SFX_UI); bank-0 NONBANKED |
 | NPC portraits | `src/npc_*_portrait.c/.h` | Per-NPC portrait tile data |
 | Turret | `src/turret.c/.h` | Static turret emplacements: SoA pool, 16-direction aim, fire timer (30-frame wind-up on first appearance, 45-frame interval), screen-visibility gate (no fire or hit-detect while off-screen), collision detection, OAM render |
-| Racer | `src/racer.c/.h` | Rival racer enemy: SoA pool, waypoint-following AI (hand-authored per track), lap guard (no finish trigger until one full circuit), CGB palette 1 (red tint); triggers game-over if it crosses the finish before the player |
+| Racer | `src/racer.c/.h` | Rival racer enemy: SoA pool, waypoint-following AI (hand-authored per track), 4-corner hitbox collision + gear-based velocity physics (mirrors player), lap guard (no finish trigger until one full circuit), CGB palette 1 (red tint); triggers game-over if it crosses the finish before the player |
 | Powerup | `src/powerup.c/.h` | One-shot tile-based powerup system: SoA pool (MAX_POWERUPS=4), OAM sprite per powerup, tile-overlap collect; POWERUP_TYPE_HEAL restores 50 HP and plays SFX_HEAL |
 | Loader | `src/loader.c/.h` | Bank-0 NONBANKED wrappers for VRAM asset loading and map data (NPC/powerup positions) |
 | Input | `src/input.h` | Key tick/press/release/debounce helpers |
@@ -74,7 +74,7 @@ Or load `build/nuke-raider.gb` in any GB/GBC emulator ([Emulicious](https://emul
 ### Game States
 
 `STATE_INIT` → `STATE_TITLE` → `STATE_OVERMAP` → `STATE_HUB` / `STATE_PRERACE` → `STATE_PLAYING` → `STATE_RESULTS` → `STATE_OVERMAP`
-`STATE_PLAYING` → `STATE_GAME_OVER` (on death)
+`STATE_PLAYING` → `STATE_GAME_OVER` (on death or racer wins) → `STATE_OVERMAP`
 
 ## Asset Pipeline
 

--- a/src/config.h
+++ b/src/config.h
@@ -96,9 +96,17 @@
 
 /* Racer enemy */
 #define MAX_RACERS           1u   /* SoA pool capacity; design for N, implement 1 */
-#define RACER_SPEED          5u   /* px/frame per axis; diagonal ≈ 7 px/frame (accepted) */
 #define MAX_RACER_WAYPOINTS 16u   /* WRAM copy buffer; tracks may have fewer */
 #define RACER_WP_THRESHOLD  12u   /* Manhattan advance threshold: ABS(dx)+ABS(dy) < this */
+/* Racer gear system — separate constants allow independent AI difficulty tuning.
+ * RACER_GEAR3_MAX_SPEED is 5 (< player 6) so the player can beat a perfect AI. */
+#define RACER_GEAR1_MAX_SPEED     2u
+#define RACER_GEAR1_ACCEL         2u
+#define RACER_GEAR2_MAX_SPEED     4u
+#define RACER_GEAR2_ACCEL         1u
+#define RACER_GEAR3_MAX_SPEED     5u
+#define RACER_GEAR3_ACCEL         1u
+#define RACER_GEAR_DOWNSHIFT_FRAMES  8u
 
 /* Enemy pool */
 /* Turret sprite: slot assigned at runtime via loader_get_slot(TILE_ASSET_TURRET). */

--- a/src/racer.c
+++ b/src/racer.c
@@ -21,6 +21,10 @@ static uint8_t  racer_dir[MAX_RACERS];
 static uint8_t  racer_wp_idx[MAX_RACERS];
 uint8_t  racer_active[MAX_RACERS];
 static uint8_t  racer_oam[MAX_RACERS * 4u];
+static int8_t   racer_vx[MAX_RACERS];
+static int8_t   racer_vy[MAX_RACERS];
+static uint8_t  racer_gear[MAX_RACERS];
+static uint8_t  racer_downshift_timer[MAX_RACERS];
 
 /* ---- Track-level data ---- */
 static uint8_t  s_wp_tx[MAX_RACER_WAYPOINTS];
@@ -91,6 +95,43 @@ static const uint8_t RACER_DIR_FLIP[8] = {
     S_FLIPX, /* LT */
 };
 
+/* ---- Directional hitbox corners — mirrors player.c HITBOX_X/Y ---- */
+static const uint8_t RACER_HITBOX_X[8][4] = {
+    {2u, 13u,  2u, 13u},  /* DIR_T  */
+    {8u, 14u,  1u,  8u},  /* DIR_RT */
+    {0u, 15u,  0u, 15u},  /* DIR_R  */
+    {1u,  8u,  8u, 14u},  /* DIR_RB */
+    {2u, 13u,  2u, 13u},  /* DIR_B  */
+    {8u, 14u,  1u,  8u},  /* DIR_LB */
+    {0u, 15u,  0u, 15u},  /* DIR_L  */
+    {1u,  8u,  8u, 14u},  /* DIR_LT */
+};
+static const uint8_t RACER_HITBOX_Y[8][4] = {
+    {0u,  0u, 15u, 15u},  /* DIR_T  */
+    {1u,  8u,  8u, 14u},  /* DIR_RT */
+    {2u,  2u, 13u, 13u},  /* DIR_R  */
+    {8u,  1u, 14u,  8u},  /* DIR_RB */
+    {0u,  0u, 15u, 15u},  /* DIR_B  */
+    {1u,  8u,  8u, 14u},  /* DIR_LB */
+    {2u,  2u, 13u, 13u},  /* DIR_L  */
+    {8u,  1u, 14u,  8u},  /* DIR_LT */
+};
+
+/* ---- Gear LUTs — racer-specific tuning (RACER_GEAR3_MAX_SPEED=5, player=6) ---- */
+static const uint8_t RACER_GEAR_MAX_SPD[3] = {RACER_GEAR1_MAX_SPEED, RACER_GEAR2_MAX_SPEED, RACER_GEAR3_MAX_SPEED};
+static const uint8_t RACER_GEAR_ACCEL_TBL[3] = {RACER_GEAR1_ACCEL, RACER_GEAR2_ACCEL, RACER_GEAR3_ACCEL};
+
+/* ---- 4-corner passability check (dir-specific hitbox, no turret check for racer) ---- */
+static uint8_t racer_corners_passable(int16_t wx, int16_t wy, uint8_t dir) {
+    uint8_t i;
+    for (i = 0u; i < 4u; i++) {
+        int16_t cx = wx + (int16_t)RACER_HITBOX_X[dir][i];
+        int16_t cy = wy + (int16_t)RACER_HITBOX_Y[dir][i];
+        if (!track_passable(cx, cy)) return 0u;
+    }
+    return 1u;
+}
+
 /* ---- Direction from delta ---- */
 static uint8_t racer_dir_from_delta(int8_t dx, int8_t dy) {
     int8_t ax = dx < 0 ? -dx : dx;
@@ -134,6 +175,10 @@ void racer_init(uint8_t tile_base) BANKED {
 
     for (i = 0u; i < MAX_RACERS; i++) {
         racer_active[i] = 0u;
+        racer_vx[i] = 0;
+        racer_vy[i] = 0;
+        racer_gear[i] = 0u;
+        racer_downshift_timer[i] = 0u;
     }
     s_tile_base  = tile_base;
     s_laps_done  = 0u;
@@ -173,6 +218,10 @@ void racer_init_empty(void) BANKED {
     uint8_t i;
     for (i = 0u; i < MAX_RACERS; i++) {
         racer_active[i] = 0u;
+        racer_vx[i] = 0;
+        racer_vy[i] = 0;
+        racer_gear[i] = 0u;
+        racer_downshift_timer[i] = 0u;
     }
     s_wp_count  = 0u;
     s_laps_done = 0u;
@@ -248,13 +297,95 @@ uint8_t racer_update(void) BANKED {
             }
         }
 
+        /* ---- Gear physics (mirrors player_apply_physics, always full throttle) ---- */
         {
-            /* TODO(Task 3): replace with gear-physics + axis-split collision */
-            int16_t new_px = racer_px[i] + (int16_t)RACER_DIR_DX[dir] * (int16_t)RACER_GEAR3_MAX_SPEED;
-            int16_t new_py = racer_py[i] + (int16_t)RACER_DIR_DY[dir] * (int16_t)RACER_GEAR3_MAX_SPEED;
-            if (track_passable(new_px, new_py)) {
+            uint8_t fric_x;
+            uint8_t fric_y;
+            uint8_t gas;
+            uint8_t j;
+            uint8_t max_speed;
+            uint8_t spd_x;
+            uint8_t spd_y;
+            uint8_t speed;
+
+            gas = (tile_type != TILE_OIL) ? 1u : 0u;
+
+            if (tile_type == TILE_SAND) {
+                fric_x = (gas && RACER_DIR_DX[dir] != 0) ? 0u : (uint8_t)(PLAYER_FRICTION * TERRAIN_SAND_FRICTION_MUL);
+                fric_y = (gas && RACER_DIR_DY[dir] != 0) ? 0u : (uint8_t)(PLAYER_FRICTION * TERRAIN_SAND_FRICTION_MUL);
+            } else if (tile_type == TILE_OIL) {
+                fric_x = 0u;
+                fric_y = 0u;
+                racer_gear[i] = 0u;
+                racer_downshift_timer[i] = 0u;
+            } else {
+                fric_x = (gas && RACER_DIR_DX[dir] != 0) ? 0u : (uint8_t)PLAYER_FRICTION;
+                fric_y = (gas && RACER_DIR_DY[dir] != 0) ? 0u : (uint8_t)PLAYER_FRICTION;
+            }
+
+            for (j = 0u; j < fric_x; j++) {
+                if      (racer_vx[i] > 0) racer_vx[i] = (int8_t)(racer_vx[i] - 1);
+                else if (racer_vx[i] < 0) racer_vx[i] = (int8_t)(racer_vx[i] + 1);
+            }
+            for (j = 0u; j < fric_y; j++) {
+                if      (racer_vy[i] > 0) racer_vy[i] = (int8_t)(racer_vy[i] - 1);
+                else if (racer_vy[i] < 0) racer_vy[i] = (int8_t)(racer_vy[i] + 1);
+            }
+
+            if (gas) {
+                racer_vx[i] = (int8_t)(racer_vx[i] + (int8_t)((int8_t)RACER_GEAR_ACCEL_TBL[racer_gear[i]] * RACER_DIR_DX[dir]));
+                racer_vy[i] = (int8_t)(racer_vy[i] + (int8_t)((int8_t)RACER_GEAR_ACCEL_TBL[racer_gear[i]] * RACER_DIR_DY[dir]));
+            }
+
+            if (tile_type == TILE_BOOST) {
+                racer_vy[i] = (int8_t)(racer_vy[i] - (int8_t)TERRAIN_BOOST_DELTA);
+            }
+
+            max_speed = (tile_type == TILE_BOOST) ? TERRAIN_BOOST_MAX_SPEED : RACER_GEAR_MAX_SPD[racer_gear[i]];
+            if (racer_vx[i] >  (int8_t)max_speed) racer_vx[i] =  (int8_t)max_speed;
+            if (racer_vx[i] < -(int8_t)max_speed) racer_vx[i] = -(int8_t)max_speed;
+            if (racer_vy[i] >  (int8_t)max_speed) racer_vy[i] =  (int8_t)max_speed;
+            if (racer_vy[i] < -(int8_t)max_speed) racer_vy[i] = -(int8_t)max_speed;
+
+            spd_x = (racer_vx[i] < 0) ? (uint8_t)(-racer_vx[i]) : (uint8_t)racer_vx[i];
+            spd_y = (racer_vy[i] < 0) ? (uint8_t)(-racer_vy[i]) : (uint8_t)racer_vy[i];
+            speed = (spd_x > spd_y) ? spd_x : spd_y;
+
+            if (racer_gear[i] < 2u && speed >= RACER_GEAR_MAX_SPD[racer_gear[i]]) {
+                racer_gear[i]++;
+                racer_downshift_timer[i] = 0u;
+            } else if (racer_gear[i] > 0u) {
+                if (speed < RACER_GEAR_MAX_SPD[racer_gear[i] - 1u]) {
+                    racer_downshift_timer[i]++;
+                    if (racer_downshift_timer[i] >= RACER_GEAR_DOWNSHIFT_FRAMES) {
+                        racer_gear[i]--;
+                        racer_downshift_timer[i] = 0u;
+                    }
+                } else {
+                    racer_downshift_timer[i] = 0u;
+                }
+            }
+        }
+
+        /* ---- Axis-split collision ---- */
+        {
+            int16_t new_px = (int16_t)(racer_px[i] + (int16_t)racer_vx[i]);
+            int16_t new_py = (int16_t)(racer_py[i] + (int16_t)racer_vy[i]);
+
+            if (racer_corners_passable(new_px, racer_py[i], dir)) {
                 racer_px[i] = new_px;
+            } else {
+                racer_vx[i] = 0;
+                racer_gear[i] = 0u;
+                racer_downshift_timer[i] = 0u;
+            }
+
+            if (racer_corners_passable(racer_px[i], new_py, dir)) {
                 racer_py[i] = new_py;
+            } else {
+                racer_vy[i] = 0;
+                racer_gear[i] = 0u;
+                racer_downshift_timer[i] = 0u;
             }
         }
     }
@@ -341,6 +472,10 @@ void racer_spawn_for_test(int16_t px, int16_t py,
     s_finish_dir = finish_dir;
     s_lap_total  = lap_total;
     s_laps_done  = lap_total;  /* ready to trigger finish detection */
+    racer_vx[0] = 0;
+    racer_vy[0] = 0;
+    racer_gear[0] = 0u;
+    racer_downshift_timer[0] = 0u;
 }
 
 void racer_set_laps_done_for_test(uint8_t n) {
@@ -368,6 +503,19 @@ void racer_set_pos_for_test(uint8_t slot, int16_t px, int16_t py) {
 
 uint8_t racer_get_wp_idx(uint8_t slot) {
     return racer_wp_idx[slot];
+}
+
+int8_t  racer_get_vx(uint8_t slot)  { return racer_vx[slot]; }
+int8_t  racer_get_vy(uint8_t slot)  { return racer_vy[slot]; }
+uint8_t racer_get_gear(uint8_t slot) { return racer_gear[slot]; }
+int16_t racer_get_px(uint8_t slot)  { return racer_px[slot]; }
+int16_t racer_get_py(uint8_t slot)  { return racer_py[slot]; }
+void    racer_set_vel_for_test(uint8_t slot, int8_t vx, int8_t vy) {
+    racer_vx[slot] = vx;
+    racer_vy[slot] = vy;
+}
+void    racer_set_gear_for_test(uint8_t slot, uint8_t gear) {
+    racer_gear[slot] = gear;
 }
 
 #endif /* __SDCC */

--- a/src/racer.c
+++ b/src/racer.c
@@ -175,8 +175,8 @@ void racer_init(uint8_t tile_base) BANKED {
 
     for (i = 0u; i < MAX_RACERS; i++) {
         racer_active[i] = 0u;
-        racer_vx[i] = 0;
-        racer_vy[i] = 0;
+        racer_vx[i] = (int8_t)0;
+        racer_vy[i] = (int8_t)0;
         racer_gear[i] = 0u;
         racer_downshift_timer[i] = 0u;
     }
@@ -218,8 +218,8 @@ void racer_init_empty(void) BANKED {
     uint8_t i;
     for (i = 0u; i < MAX_RACERS; i++) {
         racer_active[i] = 0u;
-        racer_vx[i] = 0;
-        racer_vy[i] = 0;
+        racer_vx[i] = (int8_t)0;
+        racer_vy[i] = (int8_t)0;
         racer_gear[i] = 0u;
         racer_downshift_timer[i] = 0u;
     }
@@ -375,7 +375,7 @@ uint8_t racer_update(void) BANKED {
             if (racer_corners_passable(new_px, racer_py[i], dir)) {
                 racer_px[i] = new_px;
             } else {
-                racer_vx[i] = 0;
+                racer_vx[i] = (int8_t)0;
                 racer_gear[i] = 0u;
                 racer_downshift_timer[i] = 0u;
             }
@@ -383,7 +383,7 @@ uint8_t racer_update(void) BANKED {
             if (racer_corners_passable(racer_px[i], new_py, dir)) {
                 racer_py[i] = new_py;
             } else {
-                racer_vy[i] = 0;
+                racer_vy[i] = (int8_t)0;
                 racer_gear[i] = 0u;
                 racer_downshift_timer[i] = 0u;
             }
@@ -472,8 +472,8 @@ void racer_spawn_for_test(int16_t px, int16_t py,
     s_finish_dir = finish_dir;
     s_lap_total  = lap_total;
     s_laps_done  = lap_total;  /* ready to trigger finish detection */
-    racer_vx[0] = 0;
-    racer_vy[0] = 0;
+    racer_vx[0] = (int8_t)0;
+    racer_vy[0] = (int8_t)0;
     racer_gear[0] = 0u;
     racer_downshift_timer[0] = 0u;
 }

--- a/src/racer.c
+++ b/src/racer.c
@@ -249,8 +249,9 @@ uint8_t racer_update(void) BANKED {
         }
 
         {
-            int16_t new_px = racer_px[i] + (int16_t)RACER_DIR_DX[dir] * (int16_t)RACER_SPEED;
-            int16_t new_py = racer_py[i] + (int16_t)RACER_DIR_DY[dir] * (int16_t)RACER_SPEED;
+            /* TODO(Task 3): replace with gear-physics + axis-split collision */
+            int16_t new_px = racer_px[i] + (int16_t)RACER_DIR_DX[dir] * (int16_t)RACER_GEAR3_MAX_SPEED;
+            int16_t new_py = racer_py[i] + (int16_t)RACER_DIR_DY[dir] * (int16_t)RACER_GEAR3_MAX_SPEED;
             if (track_passable(new_px, new_py)) {
                 racer_px[i] = new_px;
                 racer_py[i] = new_py;

--- a/src/racer.h
+++ b/src/racer.h
@@ -20,6 +20,13 @@ void    racer_place_on_finish_for_test(uint8_t tx, uint8_t ty, uint8_t dir);
 void    racer_set_wp_idx_for_test(uint8_t slot, uint8_t idx);
 void    racer_set_pos_for_test(uint8_t slot, int16_t px, int16_t py);
 uint8_t racer_get_wp_idx(uint8_t slot);
+int8_t  racer_get_vx(uint8_t slot);
+int8_t  racer_get_vy(uint8_t slot);
+uint8_t racer_get_gear(uint8_t slot);
+int16_t racer_get_px(uint8_t slot);
+int16_t racer_get_py(uint8_t slot);
+void    racer_set_vel_for_test(uint8_t slot, int8_t vx, int8_t vy);
+void    racer_set_gear_for_test(uint8_t slot, uint8_t gear);
 #endif
 
 #endif /* RACER_H */

--- a/src/state_game_over.c
+++ b/src/state_game_over.c
@@ -6,7 +6,6 @@
 #include "input.h"
 #include "state_manager.h"
 #include "state_game_over.h"
-#include "state_title.h"
 BANKREF(state_game_over)
 BANKREF_EXTERN(state_game_over)
 
@@ -22,7 +21,7 @@ static void enter(void) {
 
 static void update(void) {
     if (KEY_TICKED(J_START)) {
-        state_replace(&state_title, BANK(state_title));
+        state_pop();
     }
 }
 

--- a/tests/test_racer.c
+++ b/tests/test_racer.c
@@ -128,6 +128,93 @@ void test_racer_active_exported_as_global(void) {
     TEST_ASSERT_EQUAL_UINT8(0u, racer_active[0]);
 }
 
+void test_racer_4corner_blocks_when_corner_hits_wall(void) {
+    /* Map 8×4: col 3 = wall. Racer at px=8, py=0, moving DIR_R.
+     * vx=6 injected: after gear physics vx is clamped to RACER_GEAR1_MAX_SPEED, new_px=10.
+     * Right corner = (10+15, 0+2) = (25, 2) → tx=3 = WALL.
+     * Centre = (10, 0) → tx=1 = ROAD — old single-point check would allow move. */
+    static const uint8_t map[4u * 8u] = {
+        1,1,1,0,1,1,1,1,
+        1,1,1,0,1,1,1,1,
+        1,1,1,0,1,1,1,1,
+        1,1,1,0,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 7u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(map, 8u, 4u);
+    racer_spawn_for_test(8, 0, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_E, 1u);
+    racer_set_vel_for_test(0u, 6, 0);
+    racer_update();
+    TEST_ASSERT_EQUAL_INT16(8, racer_get_px(0u));
+    TEST_ASSERT_EQUAL_INT8(0, racer_get_vx(0u));
+}
+
+void test_racer_slides_along_wall_on_y_collision(void) {
+    /* Map 8×8: row 3 = wall. Racer at px=8, py=8, DIR_RB, vel (4,4) injected.
+     * Y blocked: bottom corner hits ty=3. X clear: px advances. py stays at 8. */
+    static const uint8_t map[8u * 8u] = {
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        0,0,0,0,0,0,0,0,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 7u };
+    uint8_t wp_ty[1] = { 7u };
+    track_test_set_map(map, 8u, 8u);
+    racer_spawn_for_test(8, 8, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_S, 1u);
+    racer_set_vel_for_test(0u, 4, 4);
+    racer_update();
+    TEST_ASSERT_EQUAL_INT16(8, racer_get_py(0u));
+    TEST_ASSERT_GREATER_THAN_INT16(8, racer_get_px(0u));
+}
+
+void test_racer_accelerates_from_rest(void) {
+    /* All-road map. Racer at (24, 48), waypoint at (3, 0) → DIR_T.
+     * After 3 updates vy should be negative (accelerating north). */
+    static const uint8_t flat_map[8u * 8u] = {
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 3u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(flat_map, 8u, 8u);
+    racer_spawn_for_test(24, 48, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    racer_update();
+    racer_update();
+    racer_update();
+    TEST_ASSERT_LESS_THAN_INT8(0, racer_get_vy(0u));
+}
+
+void test_racer_wall_collision_zeroes_vx_and_gear(void) {
+    /* Map 8×4: col 2 = wall. Racer at px=0, py=0, gear=2, vx=5 injected.
+     * X move blocked by wall: vx must be 0 and gear must be 0 after update. */
+    static const uint8_t map[4u * 8u] = {
+        1,1,0,1,1,1,1,1,
+        1,1,0,1,1,1,1,1,
+        1,1,0,1,1,1,1,1,
+        1,1,0,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 7u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(map, 8u, 4u);
+    racer_spawn_for_test(0, 0, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_E, 1u);
+    racer_set_vel_for_test(0u, 5, 0);
+    racer_set_gear_for_test(0u, 2u);
+    racer_update();
+    TEST_ASSERT_EQUAL_INT8(0, racer_get_vx(0u));
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_get_gear(0u));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_racer_inactive_after_init_empty);
@@ -138,5 +225,9 @@ int main(void) {
     RUN_TEST(test_racer_no_finish_before_all_laps_done);
     RUN_TEST(test_racer_finishes_after_all_laps_done);
     RUN_TEST(test_racer_active_exported_as_global);
+    RUN_TEST(test_racer_4corner_blocks_when_corner_hits_wall);
+    RUN_TEST(test_racer_slides_along_wall_on_y_collision);
+    RUN_TEST(test_racer_accelerates_from_rest);
+    RUN_TEST(test_racer_wall_collision_zeroes_vx_and_gear);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Replaces single center-point `track_passable()` call with 4-corner axis-split collision (`RACER_HITBOX_X/Y[8][4]`) — racer now wall-slides instead of clipping through or freezing
- Adds gear-based velocity physics (3 gears, per-axis SoA arrays) mirroring `player_apply_physics()` — racer accelerates from rest, responds to sand/oil/boost terrain
- Fixes pre-existing state stack overflow in `state_game_over`: `state_replace(&state_title)` kept stack depth at 2 causing the next `state_push` to silently fail; replaced with `state_pop()` so pressing Start after game over returns to the overmap and a new race can be started normally

## Test Plan
- [x] `make test` passes (29/29)
- [x] Emulicious smoketest confirmed by user — racer accelerates, wall-slides, game-over → overmap → new race works
- [x] `bank-post-build` gates passed (ROM_0: 92% WARN, ROM_1: 97% WARN — pre-existing, no regression)
- [x] `make memory-check` — WRAM 14%, VRAM 19%, OAM 77% — all PASS

Closes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)