### PR TITLE
feat(hud): race position indicator (P:1 / P:2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Or load `build/nuke-raider.gb` in any GB/GBC emulator ([Emulicious](https://emul
 | Camera | `src/camera.c/.h` | 2D scrolling ring-buffer VRAM streaming; Y-axis row streaming + X-axis column streaming with BG-wrap split calls; 1 row + 1 column cap per VBlank; `move_bkg(cam_scx_shadow, cam_scy_shadow)` |
 | Sprite pool | `src/sprite_pool.c/.h` | OAM slot management |
 | Dialog | `src/dialog.c/.h`, `src/dialog_data.c/.h`, `src/dialog_arrow_sprite.c/.h`, `src/dialog_border_tiles.c/.h` | NPC conversation trees, branching choices, per-NPC flags, UI assets |
-| HUD | `src/hud.c/.h` | On-screen display elements; lap counter hidden for combat maps (`hud_init(map_type, lap_total)`) |
+| HUD | `src/hud.c/.h` | On-screen display elements; lap counter hidden for combat maps (`hud_init(map_type, lap_total)`); race position indicator ("P:1"/"P:2") at window cols 10–12, hidden on combat maps |
 | Music | `src/music.c/.h`, `src/music_data.c/.h` | hUGEDriver music playback |
 | SFX | `src/sfx.c/.h` | One-shot sound effects: CH4 noise (SFX_SHOOT, SFX_HIT) and CH1 tone sweep (SFX_HEAL, SFX_UI); bank-0 NONBANKED |
 | NPC portraits | `src/npc_*_portrait.c/.h` | Per-NPC portrait tile data |

--- a/src/hud.c
+++ b/src/hud.c
@@ -66,6 +66,7 @@ static uint8_t  hud_ss;           /* cached seconds-within-minute for display */
 static uint8_t  hud_lap_current;
 static uint8_t  hud_lap_total;
 static uint8_t  hud_map_type;     /* TRACK_TYPE_RACE or TRACK_TYPE_COMBAT */
+static uint8_t  hud_position;     /* 0=hidden, 1=first, 2=second */
 
 /* --- Public API --- */
 
@@ -75,6 +76,7 @@ void hud_init(uint8_t map_type, uint8_t lap_total) BANKED {
     uint8_t i;
 
     hud_map_type    = map_type;
+    hud_position    = 0u;
     hud_hp          = PLAYER_MAX_HP;
     hud_frame_tick  = 0u;
     hud_seconds     = 0u;
@@ -165,6 +167,21 @@ void hud_render(void) BANKED {
         set_win_tiles(6u, 0u, 3u, 1u, lap_tiles);
     }
 
+    /* Update position indicator tiles (cols 10-12, row 0): "P:1", "P:2", or spaces */
+    {
+        uint8_t pos_tiles[3];
+        if (hud_position == 0u) {
+            pos_tiles[0] = HUD_FONT_BASE + HUD_TILE_SPACE;
+            pos_tiles[1] = HUD_FONT_BASE + HUD_TILE_SPACE;
+            pos_tiles[2] = HUD_FONT_BASE + HUD_TILE_SPACE;
+        } else {
+            pos_tiles[0] = HUD_FONT_BASE + HUD_TILE_P;
+            pos_tiles[1] = HUD_FONT_BASE + HUD_TILE_COLON;
+            pos_tiles[2] = HUD_FONT_BASE + hud_position;  /* digit 1 or 2 */
+        }
+        set_win_tiles(10u, 0u, 3u, 1u, pos_tiles);
+    }
+
     hud_dirty = 0u;
 }
 
@@ -178,6 +195,13 @@ void hud_set_lap(uint8_t current, uint8_t total) BANKED {
     hud_lap_current = current;
     hud_lap_total   = total;
     hud_dirty       = 1u;
+}
+
+void hud_set_position(uint8_t pos) BANKED {
+    if (hud_map_type == TRACK_TYPE_COMBAT) return;
+    if (pos == hud_position) return;
+    hud_position = pos;
+    hud_dirty    = 1u;
 }
 
 uint16_t hud_get_seconds(void) BANKED { return hud_seconds; }

--- a/src/hud.h
+++ b/src/hud.h
@@ -9,6 +9,7 @@ void    hud_update(void) BANKED;        /* call in game logic phase each frame *
 void    hud_render(void) BANKED;        /* call in VBlank phase — writes win tiles when dirty */
 void    hud_set_hp(uint8_t hp) BANKED;  /* wire to player damage system */
 void    hud_set_lap(uint8_t current, uint8_t total) BANKED;
+void    hud_set_position(uint8_t pos) BANKED; /* 1=first, 2=second, 0=hidden; no-op on combat maps */
 
 /* --- Test accessors (also useful for debug) --- */
 uint16_t hud_get_seconds(void) BANKED;  /* total elapsed seconds */

--- a/src/racer.c
+++ b/src/racer.c
@@ -450,6 +450,8 @@ void racer_render(void) BANKED {
     }
 }
 
+int16_t racer_get_py(uint8_t slot) BANKED { return racer_py[slot]; }
+
 #ifndef __SDCC
 
 void racer_spawn_for_test(int16_t px, int16_t py,
@@ -509,7 +511,6 @@ int8_t  racer_get_vx(uint8_t slot)  { return racer_vx[slot]; }
 int8_t  racer_get_vy(uint8_t slot)  { return racer_vy[slot]; }
 uint8_t racer_get_gear(uint8_t slot) { return racer_gear[slot]; }
 int16_t racer_get_px(uint8_t slot)  { return racer_px[slot]; }
-int16_t racer_get_py(uint8_t slot)  { return racer_py[slot]; }
 void    racer_set_vel_for_test(uint8_t slot, int8_t vx, int8_t vy) {
     racer_vx[slot] = vx;
     racer_vy[slot] = vy;

--- a/src/racer.c
+++ b/src/racer.c
@@ -451,6 +451,11 @@ void racer_render(void) BANKED {
 }
 
 int16_t racer_get_py(uint8_t slot) BANKED { return racer_py[slot]; }
+uint8_t racer_get_laps_done(uint8_t slot) BANKED { (void)slot; return s_laps_done; }
+uint8_t racer_get_wp_idx_banked(uint8_t slot) BANKED { return racer_wp_idx[slot]; }
+uint8_t racer_get_wp_count(void) BANKED { return s_wp_count; }
+uint8_t racer_get_wp_tx(uint8_t idx) BANKED { return (idx < s_wp_count) ? s_wp_tx[idx] : 0u; }
+uint8_t racer_get_wp_ty(uint8_t idx) BANKED { return (idx < s_wp_count) ? s_wp_ty[idx] : 0u; }
 
 #ifndef __SDCC
 

--- a/src/racer.h
+++ b/src/racer.h
@@ -10,6 +10,11 @@ void    racer_hide(void) BANKED;
 uint8_t racer_update(void) BANKED;
 void    racer_render(void) BANKED;
 int16_t racer_get_py(uint8_t slot) BANKED;
+uint8_t racer_get_laps_done(uint8_t slot) BANKED;
+uint8_t racer_get_wp_idx_banked(uint8_t slot) BANKED;
+uint8_t racer_get_wp_count(void) BANKED;
+uint8_t racer_get_wp_tx(uint8_t idx) BANKED;
+uint8_t racer_get_wp_ty(uint8_t idx) BANKED;
 
 #ifndef __SDCC
 void    racer_spawn_for_test(int16_t px, int16_t py,

--- a/src/racer.h
+++ b/src/racer.h
@@ -9,6 +9,7 @@ void    racer_init_empty(void) BANKED;
 void    racer_hide(void) BANKED;
 uint8_t racer_update(void) BANKED;
 void    racer_render(void) BANKED;
+int16_t racer_get_py(uint8_t slot) BANKED;
 
 #ifndef __SDCC
 void    racer_spawn_for_test(int16_t px, int16_t py,
@@ -24,7 +25,6 @@ int8_t  racer_get_vx(uint8_t slot);
 int8_t  racer_get_vy(uint8_t slot);
 uint8_t racer_get_gear(uint8_t slot);
 int16_t racer_get_px(uint8_t slot);
-int16_t racer_get_py(uint8_t slot);
 void    racer_set_vel_for_test(uint8_t slot, int8_t vx, int8_t vy);
 void    racer_set_gear_for_test(uint8_t slot, uint8_t gear);
 #endif

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -35,10 +35,6 @@ static uint8_t cd_bg_col;    /* BG map col of the 2 countdown tiles */
 static uint8_t cd_bg_row;    /* BG map row of the 2 countdown tiles */
 static uint8_t cd_world_row; /* world tile row — passed to camera_invalidate_row() */
 
-static uint8_t sp_player_wp_idx;    /* player's next waypoint target index */
-static uint8_t sp_player_laps_done; /* player's completed waypoint cycles */
-static uint8_t sp_wp_count_cache;   /* waypoint count cached at race entry */
-
 /* Countdown digit pairs: lo=left tile, hi=right tile.
  * Phases: 0='03', 1='02', 2='01', 3='GO'
  * Character arithmetic used throughout — never bare numbers. */
@@ -94,9 +90,6 @@ static void enter(void) {
     projectile_init(loader_get_slot(TILE_ASSET_BULLET));
     turret_init(loader_get_slot(TILE_ASSET_TURRET));
     racer_init(loader_get_slot(TILE_ASSET_PLAYER));
-    sp_player_wp_idx    = 0u;
-    sp_player_laps_done = 0u;
-    sp_wp_count_cache   = racer_get_wp_count();
     powerup_init();
     lap_init(track_get_lap_count());
     active_map_type_cache = track_get_map_type();
@@ -185,31 +178,31 @@ static void update(void) {
             state_replace(&state_game_over, BANK(state_game_over));
             return;
         }
-        /* Race position: compare waypoint progress scores to avoid Y-flip on winding track */
-        if (sp_wp_count_cache > 0u) {
-            {
-                int16_t wpx = (int16_t)((uint16_t)racer_get_wp_tx(sp_player_wp_idx) * 8u + 4u);
-                int16_t wpy = (int16_t)((uint16_t)racer_get_wp_ty(sp_player_wp_idx) * 8u + 4u);
-                int16_t wdx = px - wpx;
-                int16_t wdy = py - wpy;
-                if (wdx < 0) wdx = -wdx;
-                if (wdy < 0) wdy = -wdy;
-                if (wdx > 127) wdx = 127;
-                if (wdy > 127) wdy = 127;
-                if ((uint8_t)((uint8_t)wdx + (uint8_t)wdy) < (uint8_t)(RACER_WP_THRESHOLD * 2u)) {
-                    sp_player_wp_idx++;
-                    if (sp_player_wp_idx >= sp_wp_count_cache) {
-                        sp_player_wp_idx  = 0u;
-                        sp_player_laps_done++;
-                    }
-                }
-            }
-            {
-                uint8_t racer_laps  = racer_get_laps_done(0u);
-                uint8_t racer_wp    = racer_get_wp_idx_banked(0u);
-                uint8_t player_prog = (uint8_t)(sp_player_laps_done * sp_wp_count_cache + sp_player_wp_idx);
-                uint8_t racer_prog  = (uint8_t)(racer_laps  * sp_wp_count_cache + racer_wp);
-                if (player_prog >= racer_prog) { hud_set_position(1u); } else { hud_set_position(2u); }
+        /* Race position: lap count primary, section-aware ty secondary */
+        {
+            uint8_t player_laps = (uint8_t)(lap_get_current() - 1u);
+            uint8_t racer_laps  = racer_get_laps_done(0u);
+            if (player_laps > racer_laps) {
+                hud_set_position(1u);
+            } else if (player_laps < racer_laps) {
+                hud_set_position(2u);
+            } else {
+                /* Same lap: right side (tx>10) goes DOWN (higher ty=ahead);
+                 * left side (tx<=10) goes UP (lower ty=ahead).
+                 * racer_wp_idx<6 = right side, >=6 = left side. */
+                uint8_t player_tx    = (uint8_t)((uint16_t)px >> 3u);
+                uint8_t player_ty    = (uint8_t)((uint16_t)py >> 3u);
+                uint8_t racer_wp     = racer_get_wp_idx_banked(0u);
+                int16_t rpy_val      = racer_get_py(0u);
+                uint8_t racer_ty     = (uint8_t)((uint16_t)rpy_val >> 3u);
+                uint8_t player_right = (player_tx > 10u) ? 1u : 0u;
+                uint8_t racer_right  = (racer_wp  <  6u) ? 1u : 0u;
+                uint8_t pos;
+                if      ( player_right && !racer_right) { pos = 2u; }
+                else if (!player_right &&  racer_right) { pos = 1u; }
+                else if ( player_right) { pos = (player_ty >= racer_ty) ? 1u : 2u; }
+                else                   { pos = (player_ty <= racer_ty) ? 1u : 2u; }
+                hud_set_position(pos);
             }
         }
         powerup_update((uint8_t)((uint16_t)px >> 3u), (uint8_t)((uint16_t)py >> 3u));

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -178,6 +178,11 @@ static void update(void) {
             state_replace(&state_game_over, BANK(state_game_over));
             return;
         }
+        /* Race position indicator: sample racer Y after move, before HUD update */
+        {
+            int16_t rpy = racer_get_py(0u);
+            if (py < rpy) { hud_set_position(1u); } else { hud_set_position(2u); }
+        }
         powerup_update((uint8_t)((uint16_t)px >> 3u), (uint8_t)((uint16_t)py >> 3u));
         hud_set_hp(damage_get_hp());    /* sync damage HP to HUD each frame */
         camera_update(px, py);

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -35,6 +35,10 @@ static uint8_t cd_bg_col;    /* BG map col of the 2 countdown tiles */
 static uint8_t cd_bg_row;    /* BG map row of the 2 countdown tiles */
 static uint8_t cd_world_row; /* world tile row — passed to camera_invalidate_row() */
 
+static uint8_t sp_player_wp_idx;    /* player's next waypoint target index */
+static uint8_t sp_player_laps_done; /* player's completed waypoint cycles */
+static uint8_t sp_wp_count_cache;   /* waypoint count cached at race entry */
+
 /* Countdown digit pairs: lo=left tile, hi=right tile.
  * Phases: 0='03', 1='02', 2='01', 3='GO'
  * Character arithmetic used throughout — never bare numbers. */
@@ -90,6 +94,9 @@ static void enter(void) {
     projectile_init(loader_get_slot(TILE_ASSET_BULLET));
     turret_init(loader_get_slot(TILE_ASSET_TURRET));
     racer_init(loader_get_slot(TILE_ASSET_PLAYER));
+    sp_player_wp_idx    = 0u;
+    sp_player_laps_done = 0u;
+    sp_wp_count_cache   = racer_get_wp_count();
     powerup_init();
     lap_init(track_get_lap_count());
     active_map_type_cache = track_get_map_type();
@@ -178,10 +185,32 @@ static void update(void) {
             state_replace(&state_game_over, BANK(state_game_over));
             return;
         }
-        /* Race position indicator: sample racer Y after move, before HUD update */
-        {
-            int16_t rpy = racer_get_py(0u);
-            if (py < rpy) { hud_set_position(1u); } else { hud_set_position(2u); }
+        /* Race position: compare waypoint progress scores to avoid Y-flip on winding track */
+        if (sp_wp_count_cache > 0u) {
+            {
+                int16_t wpx = (int16_t)((uint16_t)racer_get_wp_tx(sp_player_wp_idx) * 8u + 4u);
+                int16_t wpy = (int16_t)((uint16_t)racer_get_wp_ty(sp_player_wp_idx) * 8u + 4u);
+                int16_t wdx = px - wpx;
+                int16_t wdy = py - wpy;
+                if (wdx < 0) wdx = -wdx;
+                if (wdy < 0) wdy = -wdy;
+                if (wdx > 127) wdx = 127;
+                if (wdy > 127) wdy = 127;
+                if ((uint8_t)((uint8_t)wdx + (uint8_t)wdy) < (uint8_t)(RACER_WP_THRESHOLD * 2u)) {
+                    sp_player_wp_idx++;
+                    if (sp_player_wp_idx >= sp_wp_count_cache) {
+                        sp_player_wp_idx  = 0u;
+                        sp_player_laps_done++;
+                    }
+                }
+            }
+            {
+                uint8_t racer_laps  = racer_get_laps_done(0u);
+                uint8_t racer_wp    = racer_get_wp_idx_banked(0u);
+                uint8_t player_prog = (uint8_t)(sp_player_laps_done * sp_wp_count_cache + sp_player_wp_idx);
+                uint8_t racer_prog  = (uint8_t)(racer_laps  * sp_wp_count_cache + racer_wp);
+                if (player_prog >= racer_prog) { hud_set_position(1u); } else { hud_set_position(2u); }
+            }
         }
         powerup_update((uint8_t)((uint16_t)px >> 3u), (uint8_t)((uint16_t)py >> 3u));
         hud_set_hp(damage_get_hp());    /* sync damage HP to HUD each frame */

--- a/tests/test_hud.c
+++ b/tests/test_hud.c
@@ -146,6 +146,34 @@ void test_hud_init_combat_mode_sets_map_type(void) {
     TEST_ASSERT_EQUAL_UINT8(0u, hud_is_dirty());
 }
 
+/* --- hud_set_position(): race mode --- */
+void test_set_position_race_sets_dirty(void) {
+    /* setUp() calls hud_init(TRACK_TYPE_RACE, 3u) — dirty starts clear */
+    hud_set_position(1u);
+    TEST_ASSERT_EQUAL_UINT8(1u, hud_is_dirty());
+}
+
+void test_set_position_no_change_no_dirty(void) {
+    hud_set_position(1u);
+    hud_render();                /* clears dirty */
+    hud_set_position(1u);        /* same value — must not dirty */
+    TEST_ASSERT_EQUAL_UINT8(0u, hud_is_dirty());
+}
+
+void test_set_position_change_sets_dirty(void) {
+    hud_set_position(1u);
+    hud_render();
+    hud_set_position(2u);        /* value changed — must dirty */
+    TEST_ASSERT_EQUAL_UINT8(1u, hud_is_dirty());
+}
+
+/* --- hud_set_position(): combat mode guard --- */
+void test_set_position_combat_noop(void) {
+    hud_init(TRACK_TYPE_COMBAT, 0u);
+    hud_set_position(1u);        /* combat mode — must be ignored */
+    TEST_ASSERT_EQUAL_UINT8(0u, hud_is_dirty());
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_init_seconds_zero);
@@ -164,5 +192,9 @@ int main(void) {
     RUN_TEST(test_set_hp_same_value_no_dirty);
     RUN_TEST(test_set_hp_changed_value_sets_dirty);
     RUN_TEST(test_hud_init_combat_mode_sets_map_type);
+    RUN_TEST(test_set_position_race_sets_dirty);
+    RUN_TEST(test_set_position_no_change_no_dirty);
+    RUN_TEST(test_set_position_change_sets_dirty);
+    RUN_TEST(test_set_position_combat_noop);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Adds `hud_set_position()` to the HUD module — writes "P:1" or "P:2" to window cols 10–12; no-op on combat maps
- Promotes `racer_get_py()` and adds 5 new BANKED accessors (`racer_get_laps_done`, `racer_get_wp_idx_banked`, `racer_get_wp_count`, `racer_get_wp_tx`, `racer_get_wp_ty`) to the public racer API
- Wires position comparison in `state_playing.c`: lap count primary, section-aware tile-X/Y comparison for same-lap (right side tx>10 → higher ty=ahead; left side tx≤10 → lower ty=ahead)

## Test Plan
- [x] `make test` passes (4 new hud tests, 497 total, 0 failures)
- [x] Emulicious smoketest confirmed: P:1/P:2 stable, no flickering, combat map shows blank cols 10–12, no HUD regression
- [x] bank-post-build: exit 0 (ROM_0 92%, ROM_1 98% WARNs are pre-existing baseline)
- [x] memory-check: WRAM 14%, VRAM 19%, OAM 77% — all PASS

## Notes
- Raw Y comparison is broken on track2's oval layout — documented in issue #377
- Section boundary: `player_tx > 10` (right side going down) vs `≤ 10` (left side going up); racer side via `racer_wp_idx < 6`

Closes #362