### PR TITLE
feat: racer/player collision — blocking and ram damage (#364)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -107,6 +107,7 @@
 #define RACER_GEAR3_MAX_SPEED     5u
 #define RACER_GEAR3_ACCEL         1u
 #define RACER_GEAR_DOWNSHIFT_FRAMES  8u
+#define RACER_RAM_DAMAGE      5u    /* HP damage on player/racer collision */
 
 /* Enemy pool */
 /* Turret sprite: slot assigned at runtime via loader_get_slot(TILE_ASSET_TURRET). */

--- a/src/player.c
+++ b/src/player.c
@@ -12,6 +12,7 @@
 #include "projectile.h"
 #include "sfx.h"
 #include "turret.h"
+#include "racer.h"
 
 int16_t px;
 int16_t py;
@@ -97,6 +98,10 @@ static uint8_t corner_active_turret(int16_t wx, int16_t wy) {
     return turret_blocks_tile(tx, ty);
 }
 
+static uint8_t corner_active_racer(int16_t wx, int16_t wy) {
+    return racer_blocks_pixel(wx, wy);
+}
+
 /* Directional hitbox points indexed by player_dir_t (0-7).
  * Cardinal dirs: rectangle inset ~2px on sides perpendicular to travel.
  * Diagonal dirs: diamond with points at edge midpoints. */
@@ -127,7 +132,12 @@ static uint8_t corners_passable(int16_t wx, int16_t wy) {
     for (i = 0u; i < 4u; i++) {
         int16_t cx = wx + HITBOX_X[player_dir][i];
         int16_t cy = wy + HITBOX_Y[player_dir][i];
-        if (!track_passable(cx, cy) || corner_active_turret(cx, cy)) return 0u;
+        {
+            uint8_t blocked = !track_passable(cx, cy);
+            if (!blocked) blocked = corner_active_turret(cx, cy);
+            if (!blocked) blocked = corner_active_racer(cx, cy);
+            if (blocked) return 0u;
+        }
     }
     return 1u;
 }
@@ -181,10 +191,24 @@ void player_update(void) BANKED {
     if (new_px >= 0 && new_px <= (int16_t)((uint16_t)active_map_w * 8u - 16u) && corners_passable(new_px, py)) {
         px = new_px;
     } else {
+        uint8_t k;
+        uint8_t racer_hit;
         vx = 0;
         current_gear    = 0u;
         downshift_timer = 0u;
-        damage_apply(1u);
+        racer_hit = 0u;
+        for (k = 0u; k < 4u; k++) {
+            if (corner_active_racer(new_px + HITBOX_X[player_dir][k],
+                                    py     + HITBOX_Y[player_dir][k])) {
+                racer_hit = 1u;
+                break;
+            }
+        }
+        if (racer_hit) {
+            damage_apply(RACER_RAM_DAMAGE);
+        } else {
+            damage_apply(1u);
+        }
         sfx_play(SFX_HIT);
     }
 
@@ -193,10 +217,24 @@ void player_update(void) BANKED {
     if (new_py >= 0 && new_py <= (int16_t)((uint16_t)active_map_h * 8u - 16u) && corners_passable(px, new_py)) {
         py = new_py;
     } else {
+        uint8_t k;
+        uint8_t racer_hit;
         vy = 0;
         current_gear    = 0u;
         downshift_timer = 0u;
-        damage_apply(1u);
+        racer_hit = 0u;
+        for (k = 0u; k < 4u; k++) {
+            if (corner_active_racer(px     + HITBOX_X[player_dir][k],
+                                    new_py + HITBOX_Y[player_dir][k])) {
+                racer_hit = 1u;
+                break;
+            }
+        }
+        if (racer_hit) {
+            damage_apply(RACER_RAM_DAMAGE);
+        } else {
+            damage_apply(1u);
+        }
         sfx_play(SFX_HIT);
     }
 

--- a/src/racer.c
+++ b/src/racer.c
@@ -457,6 +457,30 @@ uint8_t racer_get_wp_count(void) BANKED { return s_wp_count; }
 uint8_t racer_get_wp_tx(uint8_t idx) BANKED { return (idx < s_wp_count) ? s_wp_tx[idx] : 0u; }
 uint8_t racer_get_wp_ty(uint8_t idx) BANKED { return (idx < s_wp_count) ? s_wp_ty[idx] : 0u; }
 
+uint8_t racer_blocks_pixel(int16_t wx, int16_t wy) BANKED {
+    uint8_t i;
+    for (i = 0u; i < MAX_RACERS; i++) {
+        if (!racer_active[i]) continue;
+        if (wx >= racer_px[i] && wx < racer_px[i] + 16 &&
+            wy >= racer_py[i] && wy < racer_py[i] + 16) {
+            return 1u;
+        }
+    }
+    return 0u;
+}
+
+uint8_t racer_overlaps_player(int16_t px, int16_t py) BANKED {
+    uint8_t i;
+    for (i = 0u; i < MAX_RACERS; i++) {
+        if (!racer_active[i]) continue;
+        if (px < racer_px[i] + 16 && px + 16 > racer_px[i] &&
+            py < racer_py[i] + 16 && py + 16 > racer_py[i]) {
+            return 1u;
+        }
+    }
+    return 0u;
+}
+
 #ifndef __SDCC
 
 void racer_spawn_for_test(int16_t px, int16_t py,

--- a/src/racer.h
+++ b/src/racer.h
@@ -15,6 +15,8 @@ uint8_t racer_get_wp_idx_banked(uint8_t slot) BANKED;
 uint8_t racer_get_wp_count(void) BANKED;
 uint8_t racer_get_wp_tx(uint8_t idx) BANKED;
 uint8_t racer_get_wp_ty(uint8_t idx) BANKED;
+uint8_t racer_blocks_pixel(int16_t wx, int16_t wy) BANKED;
+uint8_t racer_overlaps_player(int16_t px, int16_t py) BANKED;
 
 #ifndef __SDCC
 void    racer_spawn_for_test(int16_t px, int16_t py,

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -21,6 +21,7 @@ BANKREF_EXTERN(state_playing)
 #include "checkpoint.h"
 #include "turret.h"
 #include "racer.h"
+#include "sfx.h"
 #include "powerup.h"
 #include "config.h"
 
@@ -177,6 +178,11 @@ static void update(void) {
         if (racer_update()) {
             state_replace(&state_game_over, BANK(state_game_over));
             return;
+        }
+        /* Racer drove into stationary player — damage if currently overlapping. */
+        if (racer_overlaps_player(px, py)) {
+            damage_apply(RACER_RAM_DAMAGE);
+            sfx_play(SFX_HIT);
         }
         /* Race position: lap count primary, section-aware ty secondary */
         {

--- a/tests/test_player.c
+++ b/tests/test_player.c
@@ -6,6 +6,7 @@
 #include "../src/damage.h"
 #include "../src/track.h"  /* active_map_h — runtime track height */
 #include "projectile.h"
+#include "../src/racer.h"
 
 /* input/prev_input globals defined in tests/mocks/input_globals.c */
 
@@ -18,6 +19,7 @@ void setUp(void) {
     mock_move_sprite_reset();
     camera_init(88, 8);  /* cam_y = 0 (clamped) */
     damage_init();
+    racer_init_empty();
     player_init(16u);
 }
 void tearDown(void) {}
@@ -562,6 +564,51 @@ void test_px_py_exported_as_global(void) {
     TEST_ASSERT_EQUAL_INT16(99, py);
 }
 
+/* ---- racer blocking player movement (issue #364) ---- */
+
+static const uint8_t s_road_12x8[8u * 12u] = {
+    1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,
+    1,1,1,1,1,1,1,1,1,1,1,1,
+};
+
+void test_player_blocked_by_racer(void) {
+    uint8_t wp_tx[1] = { 7u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(s_road_12x8, 12u, 8u);
+    racer_spawn_for_test(56, 40, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    player_set_pos(40, 40);
+    input = J_RIGHT;
+    player_update();
+    TEST_ASSERT_EQUAL_INT16(40, player_get_x());
+}
+
+void test_player_takes_racer_ram_damage(void) {
+    uint8_t hp_before;
+    uint8_t wp_tx[1] = { 7u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(s_road_12x8, 12u, 8u);
+    racer_spawn_for_test(56, 40, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    player_set_pos(40, 40);
+    hp_before = damage_get_hp();
+    input = J_RIGHT;
+    player_update();
+    TEST_ASSERT_EQUAL_UINT8(hp_before - RACER_RAM_DAMAGE, damage_get_hp());
+}
+
+void test_player_not_blocked_when_racer_inactive(void) {
+    track_test_set_map(s_road_12x8, 12u, 8u);
+    player_set_pos(40, 40);
+    input = J_RIGHT;
+    player_update();
+    TEST_ASSERT_GREATER_THAN_INT16(40, player_get_x());
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_player_init_sets_start_position);
@@ -640,5 +687,8 @@ int main(void) {
     RUN_TEST(test_player_set_dir_north);
     RUN_TEST(test_player_set_dir_south);
     RUN_TEST(test_px_py_exported_as_global);
+    RUN_TEST(test_player_blocked_by_racer);
+    RUN_TEST(test_player_takes_racer_ram_damage);
+    RUN_TEST(test_player_not_blocked_when_racer_inactive);
     return UNITY_END();
 }

--- a/tests/test_racer.c
+++ b/tests/test_racer.c
@@ -356,6 +356,63 @@ void test_racer_terrain_query_uses_top_center(void) {
     TEST_ASSERT_EQUAL_INT8(0, racer_get_vx(0u));
 }
 
+/* ---- racer_blocks_pixel ---- */
+
+void test_racer_blocks_pixel_inside(void) {
+    /* Racer at (32,32): bbox [32..47]×[32..47]. Centre pixel (40,40) → inside. */
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    TEST_ASSERT_EQUAL_UINT8(1u, racer_blocks_pixel(40, 40));
+}
+
+void test_racer_blocks_pixel_boundary(void) {
+    /* px+15=47, py+15=47 are the last valid pixels inside the bbox. */
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    TEST_ASSERT_EQUAL_UINT8(1u, racer_blocks_pixel(47, 47));
+}
+
+void test_racer_blocks_pixel_outside(void) {
+    /* wx=48: 48 < 32+16=48 is FALSE → outside. */
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_blocks_pixel(48, 32));
+}
+
+void test_racer_blocks_pixel_inactive(void) {
+    /* setUp called racer_init_empty() — no active racer. */
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_blocks_pixel(32, 32));
+}
+
+/* ---- racer_overlaps_player ---- */
+
+void test_racer_overlaps_player_when_overlapping(void) {
+    /* Racer at (32,32): bbox [32..47]×[32..47].
+     * Player at (40,40): bbox [40..55]×[40..55].
+     * Overlap region [40..47]×[40..47] — must return 1. */
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    TEST_ASSERT_EQUAL_UINT8(1u, racer_overlaps_player(40, 40));
+}
+
+void test_racer_overlaps_player_when_adjacent(void) {
+    /* Racer at (32,32), player at (48,32).
+     * Player bbox starts at 48; racer bbox ends at 47.
+     * Condition: px(48) < racer_px(32)+16=48 → FALSE. No overlap. */
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_overlaps_player(48, 32));
+}
+
+void test_racer_overlaps_player_when_inactive(void) {
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_overlaps_player(32, 32));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_racer_inactive_after_init_empty);
@@ -375,5 +432,12 @@ int main(void) {
     RUN_TEST(test_racer_boost_accelerates_upward);
     RUN_TEST(test_racer_boost_overrides_gear_max_speed);
     RUN_TEST(test_racer_terrain_query_uses_top_center);
+    RUN_TEST(test_racer_blocks_pixel_inside);
+    RUN_TEST(test_racer_blocks_pixel_boundary);
+    RUN_TEST(test_racer_blocks_pixel_outside);
+    RUN_TEST(test_racer_blocks_pixel_inactive);
+    RUN_TEST(test_racer_overlaps_player_when_overlapping);
+    RUN_TEST(test_racer_overlaps_player_when_adjacent);
+    RUN_TEST(test_racer_overlaps_player_when_inactive);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Added `racer_blocks_pixel()` and `racer_overlaps_player()` to `racer.c`/`racer.h` — 16×16 AABB collision primitives over the active racer pool
- Wired racer blocking into `player.c`: player cannot drive through the racer; ramming it applies `RACER_RAM_DAMAGE` (5 HP) instead of the wall-hit 1 HP
- Added overlap check in `state_playing.c`: when the racer drives into a stationary player, `damage_apply(RACER_RAM_DAMAGE)` fires (invincibility frames prevent double-damage if both paths trigger the same frame)

## Test Plan
- [x] `make test` passes (71 player tests, 24 racer tests, 32 suites total — 0 failures)
- [x] Emulicious smoketest confirmed by user
- [x] bank-post-build gates passed (ROM_1 100% WARN — pre-existing trend)
- [x] gb-memory-validator: WRAM 14%, VRAM 19%, OAM 77% — all PASS
- [x] `corners_passable` BANKED-call chain fixed: sequential `uint8_t blocked` stores instead of `||` chain to avoid SDCC register-clobber

Closes #364