### PR TITLE
feat: racer enemy — player can shoot and destroy racer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Or load `build/nuke-raider.gb` in any GB/GBC emulator ([Emulicious](https://emul
 | SFX | `src/sfx.c/.h` | One-shot sound effects: CH4 noise (SFX_SHOOT, SFX_HIT) and CH1 tone sweep (SFX_HEAL, SFX_UI); bank-0 NONBANKED |
 | NPC portraits | `src/npc_*_portrait.c/.h` | Per-NPC portrait tile data |
 | Turret | `src/turret.c/.h` | Static turret emplacements: SoA pool, 16-direction aim, fire timer (30-frame wind-up on first appearance, 45-frame interval), screen-visibility gate (no fire or hit-detect while off-screen), collision detection, OAM render |
-| Racer | `src/racer.c/.h` | Rival racer enemy: SoA pool, waypoint-following AI (hand-authored per track), 4-corner hitbox collision + gear-based velocity physics (mirrors player), lap guard (no finish trigger until one full circuit), CGB palette 1 (red tint); triggers game-over if it crosses the finish before the player |
+| Racer | `src/racer.c/.h` | Rival racer enemy: SoA pool, waypoint-following AI (hand-authored per track), 4-corner hitbox collision + gear-based velocity physics (mirrors player), lap guard (no finish trigger until one full circuit), CGB palette 1 (red tint); triggers game-over if it crosses the finish before the player. Shootable: 5 bullet hits destroy the racer (hit flash blink per hit); race continues after death — player must still cross the finish to win |
 | Powerup | `src/powerup.c/.h` | One-shot tile-based powerup system: SoA pool (MAX_POWERUPS=4), OAM sprite per powerup, tile-overlap collect; POWERUP_TYPE_HEAL restores 50 HP and plays SFX_HEAL |
 | Loader | `src/loader.c/.h` | Bank-0 NONBANKED wrappers for VRAM asset loading and map data (NPC/powerup positions) |
 | Input | `src/input.h` | Key tick/press/release/debounce helpers |

--- a/src/config.h
+++ b/src/config.h
@@ -108,6 +108,9 @@
 #define RACER_GEAR3_ACCEL         1u
 #define RACER_GEAR_DOWNSHIFT_FRAMES  8u
 #define RACER_RAM_DAMAGE      5u    /* HP damage on player/racer collision */
+#define RACER_HP               5u   /* bullet hits to destroy racer */
+#define RACER_HIT_RADIUS       8u   /* screen-space px radius for bullet hit check */
+#define RACER_HIT_FLASH_FRAMES 8u   /* frames of hit-blink per bullet hit */
 
 /* Enemy pool */
 /* Turret sprite: slot assigned at runtime via loader_get_slot(TILE_ASSET_TURRET). */

--- a/src/racer.c
+++ b/src/racer.c
@@ -10,6 +10,7 @@
 #include "sprite_pool.h"
 #include "player.h"
 #include "banking.h"
+#include "projectile.h"
 
 /* cam_y declared in camera.c — used for screen-space Y offset in racer_render */
 extern int16_t cam_y;
@@ -25,6 +26,8 @@ static int8_t   racer_vx[MAX_RACERS];
 static int8_t   racer_vy[MAX_RACERS];
 static uint8_t  racer_gear[MAX_RACERS];
 static uint8_t  racer_downshift_timer[MAX_RACERS];
+static uint8_t  racer_hp[MAX_RACERS];
+static uint8_t  racer_hit_flash[MAX_RACERS];
 
 /* ---- Track-level data ---- */
 static uint8_t  s_wp_tx[MAX_RACER_WAYPOINTS];
@@ -179,6 +182,8 @@ void racer_init(uint8_t tile_base) BANKED {
         racer_vy[i] = (int8_t)0;
         racer_gear[i] = 0u;
         racer_downshift_timer[i] = 0u;
+        racer_hp[i]        = RACER_HP;
+        racer_hit_flash[i] = 0u;
     }
     s_tile_base  = tile_base;
     s_laps_done  = 0u;
@@ -222,6 +227,8 @@ void racer_init_empty(void) BANKED {
         racer_vy[i] = (int8_t)0;
         racer_gear[i] = 0u;
         racer_downshift_timer[i] = 0u;
+        racer_hp[i]        = RACER_HP;
+        racer_hit_flash[i] = 0u;
     }
     s_wp_count  = 0u;
     s_laps_done = 0u;
@@ -547,5 +554,9 @@ void    racer_set_vel_for_test(uint8_t slot, int8_t vx, int8_t vy) {
 void    racer_set_gear_for_test(uint8_t slot, uint8_t gear) {
     racer_gear[slot] = gear;
 }
+
+uint8_t racer_get_hp_for_test(uint8_t slot)            { return racer_hp[slot]; }
+void    racer_set_hp_for_test(uint8_t slot, uint8_t h) { racer_hp[slot] = h; }
+uint8_t racer_get_hit_flash_for_test(uint8_t slot)     { return racer_hit_flash[slot]; }
 
 #endif /* __SDCC */

--- a/src/racer.c
+++ b/src/racer.c
@@ -182,7 +182,7 @@ void racer_init(uint8_t tile_base) BANKED {
         racer_vy[i] = (int8_t)0;
         racer_gear[i] = 0u;
         racer_downshift_timer[i] = 0u;
-        racer_hp[i]        = RACER_HP;
+        racer_hp[i]        = (uint8_t)RACER_HP;
         racer_hit_flash[i] = 0u;
     }
     s_tile_base  = tile_base;
@@ -227,7 +227,7 @@ void racer_init_empty(void) BANKED {
         racer_vy[i] = (int8_t)0;
         racer_gear[i] = 0u;
         racer_downshift_timer[i] = 0u;
-        racer_hp[i]        = RACER_HP;
+        racer_hp[i]        = (uint8_t)RACER_HP;
         racer_hit_flash[i] = 0u;
     }
     s_wp_count  = 0u;
@@ -514,6 +514,8 @@ void racer_spawn_for_test(int16_t px, int16_t py,
     racer_vy[0] = (int8_t)0;
     racer_gear[0] = 0u;
     racer_downshift_timer[0] = 0u;
+    racer_hp[0]        = (uint8_t)RACER_HP;
+    racer_hit_flash[0] = 0u;
 }
 
 void racer_set_laps_done_for_test(uint8_t n) {

--- a/src/racer.c
+++ b/src/racer.c
@@ -407,7 +407,7 @@ uint8_t racer_update(void) BANKED {
             int16_t scr_cy = racer_py[i] - cam_y + 24;
             if (scr_cx >= 0 && scr_cx < 168 && scr_cy >= 0 && scr_cy < 160) {
                 if (projectile_check_hit_enemy((uint8_t)scr_cx, (uint8_t)scr_cy, RACER_HIT_RADIUS)) {
-                    racer_hp[i]--;
+                    racer_hp[i] = (uint8_t)(racer_hp[i] - 1u);
                     racer_hit_flash[i] = (uint8_t)RACER_HIT_FLASH_FRAMES;
                     if (racer_hp[i] == 0u) {
                         racer_active[i] = 0u;

--- a/src/racer.c
+++ b/src/racer.c
@@ -429,7 +429,13 @@ void racer_render(void) BANKED {
         uint8_t d;
         uint8_t flags;
 
-        if (!racer_active[i]) continue;
+        if (!racer_active[i]) {
+            move_sprite(racer_oam[i * 4u + 0u], 0u, 0u);
+            move_sprite(racer_oam[i * 4u + 1u], 0u, 0u);
+            move_sprite(racer_oam[i * 4u + 2u], 0u, 0u);
+            move_sprite(racer_oam[i * 4u + 3u], 0u, 0u);
+            continue;
+        }
 
         /* Hit flash — hide sprite on odd 2-frame intervals */
         if (racer_hit_flash[i] & 2u) {

--- a/src/racer.c
+++ b/src/racer.c
@@ -395,6 +395,26 @@ uint8_t racer_update(void) BANKED {
                 racer_downshift_timer[i] = 0u;
             }
         }
+
+        /* ---- Flash timer tick ---- */
+        if (racer_hit_flash[i] > 0u) {
+            racer_hit_flash[i] = (uint8_t)(racer_hit_flash[i] - 1u);
+        }
+
+        /* ---- Bullet hit detection (screen-space, skipped if off-screen) ---- */
+        {
+            int16_t scr_cx = racer_px[i] + 16;
+            int16_t scr_cy = racer_py[i] - cam_y + 24;
+            if (scr_cx >= 0 && scr_cx < 168 && scr_cy >= 0 && scr_cy < 160) {
+                if (projectile_check_hit_enemy((uint8_t)scr_cx, (uint8_t)scr_cy, RACER_HIT_RADIUS)) {
+                    racer_hp[i]--;
+                    racer_hit_flash[i] = (uint8_t)RACER_HIT_FLASH_FRAMES;
+                    if (racer_hp[i] == 0u) {
+                        racer_active[i] = 0u;
+                    }
+                }
+            }
+        }
     }
     return 0u;
 }
@@ -410,6 +430,15 @@ void racer_render(void) BANKED {
         uint8_t flags;
 
         if (!racer_active[i]) continue;
+
+        /* Hit flash — hide sprite on odd 2-frame intervals */
+        if (racer_hit_flash[i] & 2u) {
+            move_sprite(racer_oam[i * 4u + 0u], 0u, 0u);
+            move_sprite(racer_oam[i * 4u + 1u], 0u, 0u);
+            move_sprite(racer_oam[i * 4u + 2u], 0u, 0u);
+            move_sprite(racer_oam[i * 4u + 3u], 0u, 0u);
+            continue;
+        }
 
         scr_x = racer_px[i] + 8;
         scr_y = racer_py[i] - cam_y + 16;

--- a/src/racer.h
+++ b/src/racer.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include "banking.h"
 
+extern uint8_t racer_active[];   /* SoA active flags — exported for state queries */
+
 void    racer_init(uint8_t tile_base) BANKED;
 void    racer_init_empty(void) BANKED;
 void    racer_hide(void) BANKED;

--- a/src/racer.h
+++ b/src/racer.h
@@ -34,6 +34,9 @@ uint8_t racer_get_gear(uint8_t slot);
 int16_t racer_get_px(uint8_t slot);
 void    racer_set_vel_for_test(uint8_t slot, int8_t vx, int8_t vy);
 void    racer_set_gear_for_test(uint8_t slot, uint8_t gear);
+uint8_t racer_get_hp_for_test(uint8_t slot);
+void    racer_set_hp_for_test(uint8_t slot, uint8_t hp);
+uint8_t racer_get_hit_flash_for_test(uint8_t slot);
 #endif
 
 #endif /* RACER_H */

--- a/tests/test_racer.c
+++ b/tests/test_racer.c
@@ -5,12 +5,14 @@
 #include "track.h"
 #include "checkpoint.h"
 #include "player.h"    /* player_dir_t: DIR_T, DIR_B, etc. */
+#include "projectile.h"
 
 extern int16_t cam_y;
 
 void setUp(void) {
     cam_y = 0;
     racer_init_empty();
+    projectile_init(0u);
 }
 void tearDown(void) {}
 
@@ -413,6 +415,15 @@ void test_racer_overlaps_player_when_inactive(void) {
     TEST_ASSERT_EQUAL_UINT8(0u, racer_overlaps_player(32, 32));
 }
 
+void test_racer_hp_initialized_to_racer_hp(void) {
+    /* racer_init_empty() called in setUp; HP must equal RACER_HP */
+    TEST_ASSERT_EQUAL_UINT8(RACER_HP, racer_get_hp_for_test(0u));
+}
+
+void test_racer_hit_flash_initialized_to_zero(void) {
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_get_hit_flash_for_test(0u));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_racer_inactive_after_init_empty);
@@ -439,5 +450,7 @@ int main(void) {
     RUN_TEST(test_racer_overlaps_player_when_overlapping);
     RUN_TEST(test_racer_overlaps_player_when_adjacent);
     RUN_TEST(test_racer_overlaps_player_when_inactive);
+    RUN_TEST(test_racer_hp_initialized_to_racer_hp);
+    RUN_TEST(test_racer_hit_flash_initialized_to_zero);
     return UNITY_END();
 }

--- a/tests/test_racer.c
+++ b/tests/test_racer.c
@@ -424,6 +424,71 @@ void test_racer_hit_flash_initialized_to_zero(void) {
     TEST_ASSERT_EQUAL_UINT8(0u, racer_get_hit_flash_for_test(0u));
 }
 
+void test_racer_bullet_hit_reduces_hp(void) {
+    /* cam_y=0 (setUp). Racer at world (32,32).
+     * Screen-space OAM center = (32+16, 32+24) = (48, 56).
+     * Fire player bullet at (48,56). racer_update() must decrement HP by 1. */
+    static const uint8_t flat_map[8u * 8u] = {
+        1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(flat_map, 8u, 8u);
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    racer_set_hp_for_test(0u, RACER_HP);
+    projectile_fire(48u, 56u, DIR_T, PROJ_OWNER_PLAYER);
+    racer_update();
+    TEST_ASSERT_EQUAL_UINT8(RACER_HP - 1u, racer_get_hp_for_test(0u));
+}
+
+void test_racer_destroyed_when_hp_reaches_zero(void) {
+    /* Racer at HP=1. One bullet hit deactivates it. */
+    static const uint8_t flat_map[8u * 8u] = {
+        1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(flat_map, 8u, 8u);
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    racer_set_hp_for_test(0u, 1u);
+    projectile_fire(48u, 56u, DIR_T, PROJ_OWNER_PLAYER);
+    racer_update();
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_active[0]);
+}
+
+void test_racer_dead_does_not_trigger_game_over(void) {
+    /* Racer killed by bullet. Subsequent racer_update must return 0 (no game over). */
+    static const uint8_t flat_map[8u * 8u] = {
+        1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(flat_map, 8u, 8u);
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    racer_set_hp_for_test(0u, 1u);
+    projectile_fire(48u, 56u, DIR_T, PROJ_OWNER_PLAYER);
+    racer_update();              /* kills racer */
+    TEST_ASSERT_EQUAL_UINT8(0u, racer_update()); /* no game over after death */
+}
+
+void test_racer_miss_does_not_reduce_hp(void) {
+    /* Bullet fired far from racer — HP must not change. */
+    static const uint8_t flat_map[8u * 8u] = {
+        1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,
+        1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,
+    };
+    uint8_t wp_tx[1] = { 4u };
+    uint8_t wp_ty[1] = { 0u };
+    track_test_set_map(flat_map, 8u, 8u);
+    racer_spawn_for_test(32, 32, wp_tx, wp_ty, 1u, CHECKPOINT_DIR_N, 1u);
+    projectile_fire(8u, 16u, DIR_T, PROJ_OWNER_PLAYER); /* top-left corner, far from racer */
+    racer_update();
+    TEST_ASSERT_EQUAL_UINT8(RACER_HP, racer_get_hp_for_test(0u));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_racer_inactive_after_init_empty);
@@ -452,5 +517,9 @@ int main(void) {
     RUN_TEST(test_racer_overlaps_player_when_inactive);
     RUN_TEST(test_racer_hp_initialized_to_racer_hp);
     RUN_TEST(test_racer_hit_flash_initialized_to_zero);
+    RUN_TEST(test_racer_bullet_hit_reduces_hp);
+    RUN_TEST(test_racer_destroyed_when_hp_reaches_zero);
+    RUN_TEST(test_racer_dead_does_not_trigger_game_over);
+    RUN_TEST(test_racer_miss_does_not_reduce_hp);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Adds `RACER_HP = 5u` — racer requires 5 bullet hits to destroy
- Hit detection runs inside `racer_update()` via `projectile_check_hit_enemy()` (same pattern as turrets); 8-frame hit flash blink on each hit
- Dead racer's OAM sprites are immediately hidden in `racer_render()`; race continues — player must still cross the finish to win
- No changes to `state_playing.c`

## Test Plan
- [x] `make test` passes — 6 new racer tests (HP init, flash init, bullet reduces HP, destroyed at 0 HP, dead racer no game-over, miss no HP change)
- [x] Clean ROM build, zero errors
- [x] `make memory-check` all budgets PASS (WRAM 14%, VRAM 19%, OAM 77%)
- [x] `bank-post-build` WARN only (ROM_0 92%, ROM_1 100% — pre-existing, no regression)
- [x] Emulicious smoketest: racer blinks on hit, disappears after 5 shots, no ghost sprites after death
- [x] Race still completable after racer death

## Notes
- Lap-not-counted bug when racer blocks finish line is pre-existing from PR #364 — tracked separately in #382

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)