### PR TITLE
fix: replace velocity checks with player_dir in finish_eval and checkpoint_update

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -414,7 +414,8 @@
       "Bash(timeout 5 ./build/test_gamestate)",
       "Bash(timeout 5 ./build/test_loader)",
       "Bash(timeout 5 ./build/test_hub_data)",
-      "Bash(node -e ' *)"
+      "Bash(node -e ' *)",
+      "Bash(./build/test_state_playing *)"
     ]
   },
   "hooks": {

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -1,4 +1,5 @@
 #pragma bank 255
+#include "player.h"
 #include "checkpoint.h"
 #include "config.h"
 
@@ -13,7 +14,7 @@ void checkpoint_init(const CheckpointDef *defs, uint8_t count) BANKED {
     cp_next  = 0u;
 }
 
-void checkpoint_update(int16_t px, int16_t py, int8_t vx, int8_t vy) BANKED {
+void checkpoint_update(int16_t px, int16_t py, uint8_t pdir) BANKED {
     const CheckpointDef *cp;
     if (cp_next >= cp_count) return;
     cp = &cp_defs[cp_next];
@@ -24,11 +25,13 @@ void checkpoint_update(int16_t px, int16_t py, int8_t vx, int8_t vy) BANKED {
     if (px >= (int16_t)(cp->x + cp->w))      return;
     if (py < cp->y)                          return;
     if (py >= (int16_t)(cp->y + cp->h))      return;
-    /* Direction check — if/else is equivalent to switch on SDCC/SM83 for 4 constants */
-    if (cp->direction == CHECKPOINT_DIR_N)      { if (vy >= 0) return; }
-    else if (cp->direction == CHECKPOINT_DIR_S) { if (vy <= 0) return; }
-    else if (cp->direction == CHECKPOINT_DIR_E) { if (vx <= 0) return; }
-    else if (cp->direction == CHECKPOINT_DIR_W) { if (vx >= 0) return; }
+    /* Direction check — if/else is equivalent to switch on SDCC/SM83 for 4 constants.
+     * Uses facing direction (pdir) instead of velocity to avoid racer-blocking bug
+     * where collision zeroes vx/vy and silently skips the checkpoint. */
+    if      (cp->direction == CHECKPOINT_DIR_N) { if (pdir != DIR_T  && pdir != DIR_RT && pdir != DIR_LT) return; }
+    else if (cp->direction == CHECKPOINT_DIR_S) { if (pdir != DIR_B  && pdir != DIR_RB && pdir != DIR_LB) return; }
+    else if (cp->direction == CHECKPOINT_DIR_E) { if (pdir != DIR_R  && pdir != DIR_RT && pdir != DIR_RB) return; }
+    else if (cp->direction == CHECKPOINT_DIR_W) { if (pdir != DIR_L  && pdir != DIR_LT && pdir != DIR_LB) return; }
     cp_next++;
 }
 

--- a/src/checkpoint.h
+++ b/src/checkpoint.h
@@ -2,12 +2,14 @@
 #define CHECKPOINT_H
 
 #include <gb/gb.h>
+/* Note: callers needing DIR_* constants must include "player.h" before this header.
+ * checkpoint.h cannot include player.h directly — player.h → track.h → checkpoint.h (cycle). */
 
 /* Direction constants — match Tiled 'direction' property values */
-#define CHECKPOINT_DIR_N 0u  /* north: vy < 0 */
-#define CHECKPOINT_DIR_S 1u  /* south: vy > 0 */
-#define CHECKPOINT_DIR_E 2u  /* east:  vx > 0 */
-#define CHECKPOINT_DIR_W 3u  /* west:  vx < 0 */
+#define CHECKPOINT_DIR_N 0u  /* north: player facing DIR_T/RT/LT */
+#define CHECKPOINT_DIR_S 1u  /* south: player facing DIR_B/RB/LB */
+#define CHECKPOINT_DIR_E 2u  /* east:  player facing DIR_R/RT/RB */
+#define CHECKPOINT_DIR_W 3u  /* west:  player facing DIR_L/LT/LB */
 
 /* Static descriptor for one checkpoint — populated by tmx_to_c.py-generated C.
  * Used as a ROM table (generated files) and a WRAM copy buffer (track.c).
@@ -26,8 +28,8 @@ typedef struct {
 void    checkpoint_init(const CheckpointDef *defs, uint8_t count) BANKED;
 
 /* checkpoint_update: call every frame after player_update().
- * px, py = player top-left world position; vx, vy = player velocity (int8_t matches player API). */
-void    checkpoint_update(int16_t px, int16_t py, int8_t vx, int8_t vy) BANKED;
+ * px, py = player top-left world position; pdir = player facing direction (uint8_t, DIR_* constants). */
+void    checkpoint_update(int16_t px, int16_t py, uint8_t pdir) BANKED;
 
 /* Returns 1 if all checkpoints cleared (or count == 0), 0 otherwise. */
 uint8_t checkpoint_all_cleared(void) BANKED;

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -158,8 +158,6 @@ static void update(void) {
     {
         int16_t px   = player_get_x();
         int16_t py   = player_get_y();
-        int8_t  pvx  = player_get_vx();
-        int8_t  pvy  = player_get_vy();
         uint8_t pdir = (uint8_t)player_get_dir();
         int16_t y_max;
         TileType ct;
@@ -172,7 +170,7 @@ static void update(void) {
             player_set_pos(px, py);
         }
         /* Checkpoint update — runs after player_update() and HUD clamp */
-        checkpoint_update(px, py, pvx, pvy);
+        checkpoint_update(px, py, pdir);
         projectile_update();
         turret_update(px, py);
         if (racer_update()) {
@@ -227,9 +225,10 @@ static void update(void) {
          * - checkpoint_all_cleared() gate: all CPs must be crossed in order */
         ct = track_tile_type((int16_t)(px + 4), (int16_t)(py + 4));
         if (ct == TILE_FINISH) {
+            uint8_t cps_ok = checkpoint_all_cleared();
             if (finish_eval(active_map_type_cache, finish_armed,
                             pdir, finish_dir_cache,
-                            checkpoint_all_cleared())) {
+                            cps_ok)) {
                 finish_armed = 0u;
                 if (active_map_type_cache == TRACK_TYPE_COMBAT) {
                     state_pop();

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -52,14 +52,14 @@ uint8_t
 static uint8_t
 #endif
 finish_eval(uint8_t map_type, uint8_t armed,
-            int8_t pvx, int8_t pvy,
+            player_dir_t pdir,
             uint8_t finish_dir,
             uint8_t cps_cleared) {
     if (!armed) return 0u;
-    if      (finish_dir == CHECKPOINT_DIR_N) { if (pvy >= 0) return 0u; }
-    else if (finish_dir == CHECKPOINT_DIR_S) { if (pvy <= 0) return 0u; }
-    else if (finish_dir == CHECKPOINT_DIR_E) { if (pvx <= 0) return 0u; }
-    else if (finish_dir == CHECKPOINT_DIR_W) { if (pvx >= 0) return 0u; }
+    if      (finish_dir == CHECKPOINT_DIR_N) { if (pdir != DIR_T  && pdir != DIR_RT && pdir != DIR_LT) return 0u; }
+    else if (finish_dir == CHECKPOINT_DIR_S) { if (pdir != DIR_B  && pdir != DIR_RB && pdir != DIR_LB) return 0u; }
+    else if (finish_dir == CHECKPOINT_DIR_E) { if (pdir != DIR_R  && pdir != DIR_RT && pdir != DIR_RB) return 0u; }
+    else if (finish_dir == CHECKPOINT_DIR_W) { if (pdir != DIR_L  && pdir != DIR_LT && pdir != DIR_LB) return 0u; }
     if (map_type == TRACK_TYPE_COMBAT) return 1u;
     return cps_cleared;
 }
@@ -161,6 +161,7 @@ static void update(void) {
         int16_t py   = player_get_y();
         int8_t  pvx  = player_get_vx();
         int8_t  pvy  = player_get_vy();
+        player_dir_t pdir = player_get_dir();
         int16_t y_max;
         TileType ct;
         /* HUD boundary clamp: prevent car from entering HUD zone (screen Y >= HUD_SCANLINE).
@@ -223,12 +224,12 @@ static void update(void) {
         /* Finish line detection:
          * - tile-type check replaces hardcoded Y-row
          * - finish_armed debounces: clears on entry, re-arms on exit
-         * - vy > 0 guard: only count when moving downward (prevents backward crossing)
+         * - pdir check: player facing direction, not velocity — racer-zeroed velocity never blocks detection
          * - checkpoint_all_cleared() gate: all CPs must be crossed in order */
         ct = track_tile_type((int16_t)(px + 4), (int16_t)(py + 4));
         if (ct == TILE_FINISH) {
             if (finish_eval(active_map_type_cache, finish_armed,
-                            pvx, pvy, finish_dir_cache,
+                            pdir, finish_dir_cache,
                             checkpoint_all_cleared())) {
                 finish_armed = 0u;
                 if (active_map_type_cache == TRACK_TYPE_COMBAT) {

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -7,7 +7,6 @@
 #include "state_overmap.h"
 BANKREF(state_playing)
 BANKREF_EXTERN(state_playing)
-#include "player.h"
 #include "track.h"
 #include "camera.h"
 #include "hud.h"
@@ -52,7 +51,7 @@ uint8_t
 static uint8_t
 #endif
 finish_eval(uint8_t map_type, uint8_t armed,
-            player_dir_t pdir,
+            uint8_t pdir,
             uint8_t finish_dir,
             uint8_t cps_cleared) {
     if (!armed) return 0u;
@@ -161,7 +160,7 @@ static void update(void) {
         int16_t py   = player_get_y();
         int8_t  pvx  = player_get_vx();
         int8_t  pvy  = player_get_vy();
-        player_dir_t pdir = player_get_dir();
+        uint8_t pdir = (uint8_t)player_get_dir();
         int16_t y_max;
         TileType ct;
         /* HUD boundary clamp: prevent car from entering HUD zone (screen Y >= HUD_SCANLINE).

--- a/src/state_playing.h
+++ b/src/state_playing.h
@@ -11,7 +11,7 @@ extern const State state_playing;
 #ifndef __SDCC
 /* Test-only seam: pure win-condition logic, no hardware. */
 uint8_t finish_eval(uint8_t map_type, uint8_t armed,
-                    player_dir_t pdir,
+                    uint8_t pdir,
                     uint8_t finish_dir,
                     uint8_t cps_cleared);
 /* Test-only seam: pure countdown phase-advance logic, no hardware.

--- a/src/state_playing.h
+++ b/src/state_playing.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include "state_manager.h"
+#include "player.h"
 
 BANKREF_EXTERN(state_playing)
 extern const State state_playing;
@@ -10,7 +11,7 @@ extern const State state_playing;
 #ifndef __SDCC
 /* Test-only seam: pure win-condition logic, no hardware. */
 uint8_t finish_eval(uint8_t map_type, uint8_t armed,
-                    int8_t pvx, int8_t pvy,
+                    player_dir_t pdir,
                     uint8_t finish_dir,
                     uint8_t cps_cleared);
 /* Test-only seam: pure countdown phase-advance logic, no hardware.

--- a/tests/test_checkpoint.c
+++ b/tests/test_checkpoint.c
@@ -1,4 +1,5 @@
 #include "unity.h"
+#include "../src/player.h"
 #include "../src/checkpoint.h"
 
 void setUp(void)    {}
@@ -29,12 +30,12 @@ void test_one_checkpoint_not_cleared_at_init(void) {
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared());
 }
 
-/* Player inside rect, correct direction (S = vy > 0) -> clears */
+/* Player inside rect, correct direction (S = facing south) -> clears */
 void test_update_correct_direction_clears(void) {
     CheckpointDef defs[1];
     defs[0] = make_cp(0, 0, 32, 32, 0u, CHECKPOINT_DIR_S);
     checkpoint_init(defs, 1u);
-    checkpoint_update(5, 5, 0, 1);   /* inside, vy=1 (south) */
+    checkpoint_update(5, 5, DIR_B);   /* inside, facing south */
     TEST_ASSERT_EQUAL_UINT8(1u, checkpoint_all_cleared());
 }
 
@@ -43,7 +44,7 @@ void test_update_wrong_direction_ignored(void) {
     CheckpointDef defs[1];
     defs[0] = make_cp(0, 0, 32, 32, 0u, CHECKPOINT_DIR_S);
     checkpoint_init(defs, 1u);
-    checkpoint_update(5, 5, 0, -1);  /* inside, vy=-1 (north) -- wrong */
+    checkpoint_update(5, 5, DIR_T);   /* inside, facing north -- wrong */
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared());
 }
 
@@ -52,7 +53,7 @@ void test_update_outside_rect_ignored(void) {
     CheckpointDef defs[1];
     defs[0] = make_cp(100, 100, 32, 32, 0u, CHECKPOINT_DIR_S);
     checkpoint_init(defs, 1u);
-    checkpoint_update(5, 5, 0, 1);   /* outside rect */
+    checkpoint_update(5, 5, DIR_B);   /* outside rect */
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared());
 }
 
@@ -63,13 +64,13 @@ void test_sequential_order_enforced(void) {
     defs[1] = make_cp(100, 0, 32, 32, 1u, CHECKPOINT_DIR_S);
     checkpoint_init(defs, 2u);
     /* Try to clear cp1 first -- should be ignored */
-    checkpoint_update(110, 5, 0, 1);
+    checkpoint_update(110, 5, DIR_B);
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared());
     /* Now clear cp0 */
-    checkpoint_update(5, 5, 0, 1);
+    checkpoint_update(5, 5, DIR_B);
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared()); /* cp1 still pending */
     /* Now clear cp1 */
-    checkpoint_update(110, 5, 0, 1);
+    checkpoint_update(110, 5, DIR_B);
     TEST_ASSERT_EQUAL_UINT8(1u, checkpoint_all_cleared());
 }
 
@@ -78,42 +79,42 @@ void test_reset_restores_initial_state(void) {
     CheckpointDef defs[1];
     defs[0] = make_cp(0, 0, 32, 32, 0u, CHECKPOINT_DIR_S);
     checkpoint_init(defs, 1u);
-    checkpoint_update(5, 5, 0, 1);
+    checkpoint_update(5, 5, DIR_B);
     TEST_ASSERT_EQUAL_UINT8(1u, checkpoint_all_cleared());
     checkpoint_reset();
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared());
 }
 
-/* Direction N: vy < 0 required */
-void test_direction_north_requires_negative_vy(void) {
+/* Direction N: facing north (DIR_T, DIR_RT, DIR_LT) required */
+void test_direction_north_requires_north_facing(void) {
     CheckpointDef defs[1];
     defs[0] = make_cp(0, 0, 32, 32, 0u, CHECKPOINT_DIR_N);
     checkpoint_init(defs, 1u);
-    checkpoint_update(5, 5, 0, 1);   /* vy=1, wrong for N */
+    checkpoint_update(5, 5, DIR_B);   /* facing south, wrong for N */
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared());
-    checkpoint_update(5, 5, 0, -1);  /* vy=-1, correct for N */
+    checkpoint_update(5, 5, DIR_T);   /* facing north, correct for N */
     TEST_ASSERT_EQUAL_UINT8(1u, checkpoint_all_cleared());
 }
 
-/* Direction E: vx > 0 required */
-void test_direction_east_requires_positive_vx(void) {
+/* Direction E: facing east (DIR_R, DIR_RT, DIR_RB) required */
+void test_direction_east_requires_east_facing(void) {
     CheckpointDef defs[1];
     defs[0] = make_cp(0, 0, 32, 32, 0u, CHECKPOINT_DIR_E);
     checkpoint_init(defs, 1u);
-    checkpoint_update(5, 5, -1, 0);  /* wrong */
+    checkpoint_update(5, 5, DIR_L);   /* facing west, wrong */
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared());
-    checkpoint_update(5, 5, 1, 0);   /* correct */
+    checkpoint_update(5, 5, DIR_R);   /* facing east, correct */
     TEST_ASSERT_EQUAL_UINT8(1u, checkpoint_all_cleared());
 }
 
-/* Direction W: vx < 0 required */
-void test_direction_west_requires_negative_vx(void) {
+/* Direction W: facing west (DIR_L, DIR_LT, DIR_LB) required */
+void test_direction_west_requires_west_facing(void) {
     CheckpointDef defs[1];
     defs[0] = make_cp(0, 0, 32, 32, 0u, CHECKPOINT_DIR_W);
     checkpoint_init(defs, 1u);
-    checkpoint_update(5, 5, 1, 0);   /* wrong */
+    checkpoint_update(5, 5, DIR_R);   /* facing east, wrong */
     TEST_ASSERT_EQUAL_UINT8(0u, checkpoint_all_cleared());
-    checkpoint_update(5, 5, -1, 0);  /* correct */
+    checkpoint_update(5, 5, DIR_L);   /* facing west, correct */
     TEST_ASSERT_EQUAL_UINT8(1u, checkpoint_all_cleared());
 }
 
@@ -132,9 +133,9 @@ int main(void) {
     RUN_TEST(test_update_outside_rect_ignored);
     RUN_TEST(test_sequential_order_enforced);
     RUN_TEST(test_reset_restores_initial_state);
-    RUN_TEST(test_direction_north_requires_negative_vy);
-    RUN_TEST(test_direction_east_requires_positive_vx);
-    RUN_TEST(test_direction_west_requires_negative_vx);
+    RUN_TEST(test_direction_north_requires_north_facing);
+    RUN_TEST(test_direction_east_requires_east_facing);
+    RUN_TEST(test_direction_west_requires_west_facing);
     RUN_TEST(test_cp_next_exported_as_global);
     return UNITY_END();
 }

--- a/tests/test_state_playing.c
+++ b/tests/test_state_playing.c
@@ -5,104 +5,109 @@
 void setUp(void) {}
 void tearDown(void) {}
 
-/* finish_eval(map_type, armed, pvx, pvy, finish_dir, cps_cleared) -> 1 = transition */
+/* finish_eval(map_type, armed, pdir, finish_dir, cps_cleared) -> 1 = transition */
 
-/* --- Existing race/combat gate tests (updated to new signature, dir=S) --- */
+/* --- Race/combat gate tests (finish direction = S) --- */
 
 void test_finish_eval_race_all_conditions_met(void) {
-    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, 0, 1, CHECKPOINT_DIR_S, 1u));
+    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_B, CHECKPOINT_DIR_S, 1u));
 }
 
 void test_finish_eval_race_missing_checkpoint(void) {
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 0, 1, CHECKPOINT_DIR_S, 0u));
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_B, CHECKPOINT_DIR_S, 0u));
 }
 
 void test_finish_eval_race_not_armed(void) {
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 0u, 0, 1, CHECKPOINT_DIR_S, 1u));
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 0u, DIR_B, CHECKPOINT_DIR_S, 1u));
 }
 
 void test_finish_eval_race_wrong_direction(void) {
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 0, -1, CHECKPOINT_DIR_S, 1u));
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_T, CHECKPOINT_DIR_S, 1u));
 }
 
 void test_finish_eval_combat_no_checkpoint_needed(void) {
-    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_COMBAT, 1u, 0, 1, CHECKPOINT_DIR_S, 0u));
+    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_COMBAT, 1u, DIR_B, CHECKPOINT_DIR_S, 0u));
 }
 
 void test_finish_eval_combat_not_armed(void) {
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_COMBAT, 0u, 0, 1, CHECKPOINT_DIR_S, 0u));
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_COMBAT, 0u, DIR_B, CHECKPOINT_DIR_S, 0u));
 }
 
 void test_finish_eval_combat_wrong_direction(void) {
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_COMBAT, 1u, 0, -1, CHECKPOINT_DIR_S, 0u));
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_COMBAT, 1u, DIR_T, CHECKPOINT_DIR_S, 0u));
 }
 
-/* --- Direction N: fires when vy < 0 --- */
+/* --- Direction N: fires when facing north (DIR_T, DIR_RT, DIR_LT) --- */
 
 void test_finish_eval_dir_N_valid(void) {
-    /* vy=-1: moving north — should trigger */
-    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, 0, -1, CHECKPOINT_DIR_N, 1u));
+    /* facing north — should trigger */
+    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_T, CHECKPOINT_DIR_N, 1u));
 }
 
 void test_finish_eval_dir_N_invalid_zero(void) {
-    /* vy=0: stationary — should NOT trigger */
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 0, 0, CHECKPOINT_DIR_N, 1u));
+    /* facing east (no north component) — should NOT trigger */
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_R, CHECKPOINT_DIR_N, 1u));
 }
 
 void test_finish_eval_dir_N_invalid_south(void) {
-    /* vy=1: moving south — should NOT trigger */
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 0, 1, CHECKPOINT_DIR_N, 1u));
+    /* facing south — should NOT trigger */
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_B, CHECKPOINT_DIR_N, 1u));
 }
 
-/* --- Direction S: fires when vy > 0 --- */
+/* --- Direction S: fires when facing south (DIR_B, DIR_RB, DIR_LB) --- */
 
 void test_finish_eval_dir_S_valid(void) {
-    /* vy=1: moving south — should trigger */
-    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, 0, 1, CHECKPOINT_DIR_S, 1u));
+    /* facing south — should trigger */
+    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_B, CHECKPOINT_DIR_S, 1u));
 }
 
 void test_finish_eval_dir_S_invalid_zero(void) {
-    /* vy=0: stationary — should NOT trigger */
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 0, 0, CHECKPOINT_DIR_S, 1u));
+    /* facing east (no south component) — should NOT trigger */
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_R, CHECKPOINT_DIR_S, 1u));
 }
 
 void test_finish_eval_dir_S_invalid_north(void) {
-    /* vy=-1: moving north — should NOT trigger */
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 0, -1, CHECKPOINT_DIR_S, 1u));
+    /* facing north — should NOT trigger */
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_T, CHECKPOINT_DIR_S, 1u));
 }
 
-/* --- Direction E: fires when vx > 0 --- */
+void test_finish_eval_dir_S_racer_blocked_still_counts(void) {
+    /* Regression #382: racer zeroes pvy; player faces south — lap must still count */
+    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_B, CHECKPOINT_DIR_S, 1u));
+}
+
+/* --- Direction E: fires when facing east (DIR_R, DIR_RT, DIR_RB) --- */
 
 void test_finish_eval_dir_E_valid(void) {
-    /* vx=1: moving east — should trigger */
-    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, 1, 0, CHECKPOINT_DIR_E, 1u));
+    /* facing east — should trigger */
+    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_R, CHECKPOINT_DIR_E, 1u));
 }
 
 void test_finish_eval_dir_E_invalid_zero(void) {
-    /* vx=0: stationary — should NOT trigger */
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 0, 0, CHECKPOINT_DIR_E, 1u));
+    /* facing north (no east component) — should NOT trigger */
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_T, CHECKPOINT_DIR_E, 1u));
 }
 
 void test_finish_eval_dir_E_invalid_west(void) {
-    /* vx=-1: moving west — should NOT trigger */
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, -1, 0, CHECKPOINT_DIR_E, 1u));
+    /* facing west — should NOT trigger */
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_L, CHECKPOINT_DIR_E, 1u));
 }
 
-/* --- Direction W: fires when vx < 0 --- */
+/* --- Direction W: fires when facing west (DIR_L, DIR_LT, DIR_LB) --- */
 
 void test_finish_eval_dir_W_valid(void) {
-    /* vx=-1: moving west — should trigger */
-    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, -1, 0, CHECKPOINT_DIR_W, 1u));
+    /* facing west — should trigger */
+    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_L, CHECKPOINT_DIR_W, 1u));
 }
 
 void test_finish_eval_dir_W_invalid_zero(void) {
-    /* vx=0: stationary — should NOT trigger */
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 0, 0, CHECKPOINT_DIR_W, 1u));
+    /* facing north (no west component) — should NOT trigger */
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_T, CHECKPOINT_DIR_W, 1u));
 }
 
 void test_finish_eval_dir_W_invalid_east(void) {
-    /* vx=1: moving east — should NOT trigger */
-    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, 1, 0, CHECKPOINT_DIR_W, 1u));
+    /* facing east — should NOT trigger */
+    TEST_ASSERT_EQUAL_UINT8(0u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_R, CHECKPOINT_DIR_W, 1u));
 }
 
 void test_cd_stays_in_phase_before_threshold(void) {
@@ -140,6 +145,7 @@ int main(void) {
     RUN_TEST(test_finish_eval_dir_S_valid);
     RUN_TEST(test_finish_eval_dir_S_invalid_zero);
     RUN_TEST(test_finish_eval_dir_S_invalid_north);
+    RUN_TEST(test_finish_eval_dir_S_racer_blocked_still_counts);
     RUN_TEST(test_finish_eval_dir_E_valid);
     RUN_TEST(test_finish_eval_dir_E_invalid_zero);
     RUN_TEST(test_finish_eval_dir_E_invalid_west);

--- a/tests/test_state_playing.c
+++ b/tests/test_state_playing.c
@@ -72,8 +72,8 @@ void test_finish_eval_dir_S_invalid_north(void) {
 }
 
 void test_finish_eval_dir_S_racer_blocked_still_counts(void) {
-    /* Regression #382: racer zeroes pvy; player faces south — lap must still count */
-    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_B, CHECKPOINT_DIR_S, 1u));
+    /* Regression #382: diagonal SW approach still counts for south finish */
+    TEST_ASSERT_EQUAL_UINT8(1u, finish_eval(TRACK_TYPE_RACE, 1u, DIR_LB, CHECKPOINT_DIR_S, 1u));
 }
 
 /* --- Direction E: fires when facing east (DIR_R, DIR_RT, DIR_RB) --- */


### PR DESCRIPTION
## Summary

- **Root cause (#382):** `racer_blocks_pixel()` zeroes `vy`/`vx` at the finish tile frame, causing `finish_eval()` and `checkpoint_update()` to silently reject valid crossings
- **Fix:** Replace velocity-sign checks (`pvy <= 0`, etc.) with player-facing-direction checks (`pdir != DIR_B && ...`) in both `finish_eval()` and `checkpoint_update()`; both functions now accept `uint8_t pdir` (8-bit ABI, matching SM83 convention) instead of `pvx`/`pvy`; `pvx`/`pvy` locals fully removed from `state_playing.c`
- **Side-fix:** Materialized `checkpoint_all_cleared()` (BANKED) result to `uint8_t cps_ok` before passing to `finish_eval()` to prevent SDCC register pass-through corruption

## Test Plan

- [x] `make test` — 29/29 PASS (all direction tests rewritten with `DIR_*` enum values; regression test `test_finish_eval_dir_S_racer_blocked_still_counts` exercises `DIR_LB` diagonal acceptance)
- [x] Emulicious smoketest — lap counts correctly with racer physically blocking the finish area on track 2
- [x] bank-post-build gates passed (WARN only — pre-existing ROM_0/ROM_1 levels)
- [x] gb-memory-validator: WRAM 14%, VRAM 19%, OAM 77% — all PASS

Closes #382