### PR TITLE
fix(track2): replace 3-CP layout with 4-CP oval (S/W/N/E)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -87,7 +87,9 @@
       "PowerShell(git *)",
       "PowerShell(Start-Process -FilePath \"java\" -ArgumentList \"-jar\", \"C:\\\\Tools\\\\Emulicious\\\\Emulicious.jar\", \"build\\\\nuke-raider.gb\" -PassThru | Select-Object Id, HasExited)",
       "PowerShell(head *)",
-      "PowerShell(Start-Process -FilePath \"java\" -ArgumentList \"-jar\", \"C:\\\\Tools\\\\Emulicious\\\\Emulicious.jar\", \"C:\\\\Code\\\\nuke-raider\\\\.claude\\\\worktrees\\\\fix+race-position-checkpoint\\\\build\\\\nuke-raider.gb\" -PassThru)"
+      "PowerShell(Start-Process -FilePath \"java\" -ArgumentList \"-jar\", \"C:\\\\Tools\\\\Emulicious\\\\Emulicious.jar\", \"C:\\\\Code\\\\nuke-raider\\\\.claude\\\\worktrees\\\\fix+race-position-checkpoint\\\\build\\\\nuke-raider.gb\" -PassThru)",
+      "PowerShell(Start-Process \"C:\\\\Code\\\\nuke-raider\\\\assets\\\\maps\\\\track2.tmx\")",
+      "PowerShell(Start-Process -FilePath \"java\" -ArgumentList \"-jar\", \"C:\\\\Tools\\\\Emulicious\\\\Emulicious.jar\", \"C:\\\\Code\\\\nuke-raider\\\\build\\\\nuke-raider.gb\")"
     ]
   },
   "hooks": {

--- a/assets/maps/track2.tmx
+++ b/assets/maps/track2.tmx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.10" tiledversion="1.11.2" orientation="orthogonal" renderorder="right-down" width="20" height="100" tilewidth="8" tileheight="8" infinite="0" nextlayerid="7" nextobjectid="18">
+<map version="1.10" tiledversion="1.12.1" orientation="orthogonal" renderorder="right-down" width="20" height="100" tilewidth="8" tileheight="8" infinite="0" nextlayerid="7" nextobjectid="20">
  <properties>
   <property name="lap_count" type="int" value="3"/>
   <property name="map_type" value="race"/>
@@ -125,22 +125,28 @@
   </object>
  </objectgroup>
  <objectgroup id="4" name="checkpoints">
-  <object id="3" x="96" y="400" width="40" height="16">
+  <object id="3" x="96" y="400" width="40" height="8">
    <properties>
     <property name="direction" value="S"/>
     <property name="index" type="int" value="0"/>
    </properties>
   </object>
-  <object id="18" x="96" y="744" width="24" height="16">
+  <object id="18" x="80" y="752" width="8" height="40">
    <properties>
-    <property name="direction" value="S"/>
+    <property name="direction" value="W"/>
     <property name="index" type="int" value="1"/>
    </properties>
   </object>
-  <object id="4" x="32" y="400" width="40" height="16">
+  <object id="4" x="32" y="400" width="40" height="8">
    <properties>
     <property name="direction" value="N"/>
     <property name="index" type="int" value="2"/>
+   </properties>
+  </object>
+  <object id="19" x="80" y="8" width="8" height="40">
+   <properties>
+    <property name="direction" value="E"/>
+    <property name="index" type="int" value="3"/>
    </properties>
   </object>
  </objectgroup>

--- a/src/track2_map.c
+++ b/src/track2_map.c
@@ -133,12 +133,13 @@ const uint8_t track2_map[2002] = {
 #include "checkpoint.h"
 
 BANKREF(track2_checkpoints)
-const CheckpointDef track2_checkpoints[3] = {
-    { 96, 400, 40, 16, 0, CHECKPOINT_DIR_S },
-    { 96, 744, 24, 16, 1, CHECKPOINT_DIR_S },
-    { 32, 400, 40, 16, 2, CHECKPOINT_DIR_N },
+const CheckpointDef track2_checkpoints[4] = {
+    { 96, 400, 40, 8, 0, CHECKPOINT_DIR_S },
+    { 80, 752, 8, 40, 1, CHECKPOINT_DIR_W },
+    { 32, 400, 40, 8, 2, CHECKPOINT_DIR_N },
+    { 80, 8, 8, 40, 3, CHECKPOINT_DIR_E },
 };
-const uint8_t track2_checkpoint_count = 3;
+const uint8_t track2_checkpoint_count = 4;
 
 BANKREF(track2_npc_count)
 const uint8_t track2_npc_count = 1u;


### PR DESCRIPTION
## Summary

- Bottom checkpoint was DIR_S but player is heading west there — checkpoint never cleared, causing an extra lap every race
- Replaced the 3-checkpoint layout with 4 checkpoints covering all corners of the oval: right-lane south, bottom-stretch west, left-lane north, top-stretch east
- Fixed duplicate Tiled object ID on the new top checkpoint (was id=18, now id=19)

New checkpoint layout:
- CP0: x=96, y=400, DIR_S — right lane going south
- CP1: x=80, y=752, DIR_W — bottom stretch going west (was DIR_S — the bug)
- CP2: x=32, y=400, DIR_N — left lane going north
- CP3: x=80, y=8,   DIR_E — top stretch going east (new)

## Test plan

- [ ] Drive track 2 and verify all 4 checkpoints register each lap
- [ ] Confirm a 3-lap race ends after exactly 3 laps (not 4)
- [ ] Verify race position display is correct throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)