### PR TITLE
fix(race): Manhattan distance tiebreaker + track2 CP3 boundary fix

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -89,7 +89,10 @@
       "PowerShell(head *)",
       "PowerShell(Start-Process -FilePath \"java\" -ArgumentList \"-jar\", \"C:\\\\Tools\\\\Emulicious\\\\Emulicious.jar\", \"C:\\\\Code\\\\nuke-raider\\\\.claude\\\\worktrees\\\\fix+race-position-checkpoint\\\\build\\\\nuke-raider.gb\" -PassThru)",
       "PowerShell(Start-Process \"C:\\\\Code\\\\nuke-raider\\\\assets\\\\maps\\\\track2.tmx\")",
-      "PowerShell(Start-Process -FilePath \"java\" -ArgumentList \"-jar\", \"C:\\\\Tools\\\\Emulicious\\\\Emulicious.jar\", \"C:\\\\Code\\\\nuke-raider\\\\build\\\\nuke-raider.gb\")"
+      "PowerShell(Start-Process -FilePath \"java\" -ArgumentList \"-jar\", \"C:\\\\Tools\\\\Emulicious\\\\Emulicious.jar\", \"C:\\\\Code\\\\nuke-raider\\\\build\\\\nuke-raider.gb\")",
+      "Bash(Get-ChildItem -Path \"C:\\\\Code\\\\nuke-raider\\\\src\" -Recurse -File)",
+      "Bash(Select-Object FullName)",
+      "Bash(Sort-Object FullName)"
     ]
   },
   "hooks": {

--- a/assets/maps/track2.tmx
+++ b/assets/maps/track2.tmx
@@ -143,7 +143,7 @@
     <property name="index" type="int" value="2"/>
    </properties>
   </object>
-  <object id="19" x="80" y="8" width="8" height="40">
+  <object id="19" x="80" y="8" width="8" height="56">
    <properties>
     <property name="direction" value="E"/>
     <property name="index" type="int" value="3"/>

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -64,6 +64,25 @@ uint8_t
 #else
 static uint8_t
 #endif
+pos_from_manhattan(int16_t px,  int16_t py,
+                   int16_t rpx, int16_t rpy,
+                   const CheckpointDef *next) {
+    int16_t cx  = next->x + (int16_t)(next->w >> 1u);
+    int16_t cy  = next->y + (int16_t)(next->h >> 1u);
+    int16_t pdx = px  - cx; if (pdx < 0) pdx = -pdx;
+    int16_t pdy = py  - cy; if (pdy < 0) pdy = -pdy;
+    int16_t rdx = rpx - cx; if (rdx < 0) rdx = -rdx;
+    int16_t rdy = rpy - cy; if (rdy < 0) rdy = -rdy;
+    uint16_t pd = (uint16_t)pdx + (uint16_t)pdy;
+    uint16_t rd = (uint16_t)rdx + (uint16_t)rdy;
+    return (pd <= rd) ? 1u : 2u;
+}
+
+#ifndef __SDCC
+uint8_t
+#else
+static uint8_t
+#endif
 finish_eval(uint8_t map_type, uint8_t armed,
             uint8_t pdir,
             uint8_t finish_dir,
@@ -214,10 +233,13 @@ static void update(void) {
                     pos = 2u;
                 } else {
                     const CheckpointDef *next = checkpoint_get_next_def();
-                    uint8_t tdir = next ? next->direction : finish_dir_cache;
-                    int16_t rpx  = racer_get_px(0u);
-                    int16_t rpy  = racer_get_py(0u);
-                    pos = pos_from_dir(tdir, px, py, rpx, rpy);
+                    int16_t rpx = racer_get_px(0u);
+                    int16_t rpy = racer_get_py(0u);
+                    if (next) {
+                        pos = pos_from_manhattan(px, py, rpx, rpy, next);
+                    } else {
+                        pos = pos_from_dir(finish_dir_cache, px, py, rpx, rpy);
+                    }
                 }
             }
             hud_set_position(pos);

--- a/src/state_playing.h
+++ b/src/state_playing.h
@@ -22,6 +22,11 @@ uint8_t cd_advance(uint8_t phase, uint8_t frames);
 uint8_t pos_from_dir(uint8_t dir,
                      int16_t px,  int16_t py,
                      int16_t rpx, int16_t rpy);
+/* Test-only seam: Manhattan-distance tiebreaker to checkpoint center.
+ * Returns 1 = player ahead (closer or equal), 2 = racer ahead. */
+uint8_t pos_from_manhattan(int16_t px,  int16_t py,
+                           int16_t rpx, int16_t rpy,
+                           const CheckpointDef *next);
 #endif
 
 #endif

--- a/src/track2_map.c
+++ b/src/track2_map.c
@@ -137,7 +137,7 @@ const CheckpointDef track2_checkpoints[4] = {
     { 96, 400, 40, 8, 0, CHECKPOINT_DIR_S },
     { 80, 752, 8, 40, 1, CHECKPOINT_DIR_W },
     { 32, 400, 40, 8, 2, CHECKPOINT_DIR_N },
-    { 80, 8, 8, 40, 3, CHECKPOINT_DIR_E },
+    { 80, 8, 8, 56, 3, CHECKPOINT_DIR_E },
 };
 const uint8_t track2_checkpoint_count = 4;
 

--- a/tests/test_checkpoint.c
+++ b/tests/test_checkpoint.c
@@ -151,6 +151,39 @@ void test_checkpoint_get_next_def_returns_current_and_null(void) {
     TEST_ASSERT_NULL(checkpoint_get_next_def());
 }
 
+/* Regression: track2 CP[3] boundary — player going east at py=48 sits exactly
+ * at the AABB bottom (y + h = 8 + 40 = 48), which the AABB rejects.
+ * This simulates a full track2 lap; CP[3] must register before the finish. */
+static CheckpointDef s_track2_cps[4];
+static void setup_track2_cps(void) {
+    s_track2_cps[0] = make_cp( 96, 400, 40,  8, 0u, CHECKPOINT_DIR_S);
+    s_track2_cps[1] = make_cp( 80, 752,  8, 40, 1u, CHECKPOINT_DIR_W);
+    s_track2_cps[2] = make_cp( 32, 400, 40,  8, 2u, CHECKPOINT_DIR_N);
+    s_track2_cps[3] = make_cp( 80,   8,  8, 56, 3u, CHECKPOINT_DIR_E); /* h=56: covers y=8-64 */
+    checkpoint_init(s_track2_cps, 4u);
+}
+
+void test_track2_full_lap_py47_clears_cp3(void) {
+    setup_track2_cps();
+    checkpoint_update(100, 402, DIR_B);   /* CP0 S: right lane going south */
+    checkpoint_update( 82, 760, DIR_L);   /* CP1 W: bottom going west */
+    checkpoint_update( 40, 402, DIR_T);   /* CP2 N: left lane going north */
+    /* CP3 E: player going east at py=47 — inside [8,48) → should clear */
+    checkpoint_update( 82,  47, DIR_R);
+    TEST_ASSERT_EQUAL_UINT8(1u, checkpoint_all_cleared());
+}
+
+void test_track2_cp3_clears_at_finish_boundary(void) {
+    /* Regression guard: py=48 (exact bottom of old h=40 zone) must NOW clear CP3.
+     * Fix: h changed from 40 to 56 → zone is y=8-64, so py=48 < 64 passes. */
+    setup_track2_cps();
+    checkpoint_update(100, 402, DIR_B);
+    checkpoint_update( 82, 760, DIR_L);
+    checkpoint_update( 40, 402, DIR_T);
+    checkpoint_update( 82,  48, DIR_R);   /* py=48, now inside [8,64) with h=56 */
+    TEST_ASSERT_EQUAL_UINT8(1u, checkpoint_all_cleared());
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_zero_checkpoints_all_cleared);
@@ -165,5 +198,7 @@ int main(void) {
     RUN_TEST(test_direction_west_requires_west_facing);
     RUN_TEST(test_cp_next_exported_as_global);
     RUN_TEST(test_checkpoint_get_next_def_returns_current_and_null);
+    RUN_TEST(test_track2_full_lap_py47_clears_cp3);
+    RUN_TEST(test_track2_cp3_clears_at_finish_boundary);
     return UNITY_END();
 }

--- a/tests/test_state_playing.c
+++ b/tests/test_state_playing.c
@@ -141,6 +141,29 @@ void test_pos_from_dir_W_racer_ahead(void) {
     TEST_ASSERT_EQUAL_UINT8(2u, pos_from_dir(CHECKPOINT_DIR_W, 100, 0,  50, 0));
 }
 
+/* pos_from_manhattan: smaller Manhattan distance to checkpoint center = ahead (P1).
+ * Tie (equal distance) favors player → returns 1. */
+void test_pos_from_manhattan_player_closer(void) {
+    CheckpointDef cp = {100, 100, 20, 20, 0, CHECKPOINT_DIR_N};
+    /* center=(110,110). player dist=4, racer dist=40 */
+    TEST_ASSERT_EQUAL_UINT8(1u, pos_from_manhattan(112, 112, 90, 90, &cp));
+}
+void test_pos_from_manhattan_racer_closer(void) {
+    CheckpointDef cp = {100, 100, 20, 20, 0, CHECKPOINT_DIR_N};
+    /* center=(110,110). player dist=40, racer dist=4 */
+    TEST_ASSERT_EQUAL_UINT8(2u, pos_from_manhattan(90, 90, 112, 112, &cp));
+}
+void test_pos_from_manhattan_equal_distance_favors_player(void) {
+    CheckpointDef cp = {100, 100, 20, 20, 0, CHECKPOINT_DIR_N};
+    /* center=(110,110). player dist=10, racer dist=10 */
+    TEST_ASSERT_EQUAL_UINT8(1u, pos_from_manhattan(120, 110, 110, 120, &cp));
+}
+void test_pos_from_manhattan_nonsquare_checkpoint(void) {
+    CheckpointDef cp = {0, 0, 40, 10, 0, CHECKPOINT_DIR_E};
+    /* center=(20,5). player dist=1, racer dist=20 */
+    TEST_ASSERT_EQUAL_UINT8(1u, pos_from_manhattan(21, 5, 0, 5, &cp));
+}
+
 void test_cd_stays_in_phase_before_threshold(void) {
     /* CD_FRAMES_NUM - 1 = 59 */
     TEST_ASSERT_EQUAL_UINT8(0u, cd_advance(0u, 59u));
@@ -195,5 +218,9 @@ int main(void) {
     RUN_TEST(test_pos_from_dir_E_racer_ahead);
     RUN_TEST(test_pos_from_dir_W_player_ahead);
     RUN_TEST(test_pos_from_dir_W_racer_ahead);
+    RUN_TEST(test_pos_from_manhattan_player_closer);
+    RUN_TEST(test_pos_from_manhattan_racer_closer);
+    RUN_TEST(test_pos_from_manhattan_equal_distance_favors_player);
+    RUN_TEST(test_pos_from_manhattan_nonsquare_checkpoint);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

- **Race position tiebreaker:** Replace `pos_from_dir()` (single-axis directional comparison) with `pos_from_manhattan()` — whoever is closer (Manhattan distance) to the center of the next checkpoint is ranked P1. Falls back to directional comparison when all CPs are cleared and both racers head to the finish. Validation confirmed player and racer tracking are fully independent with no cross-calls.

- **Track2 extra-lap bug:** CP3 (east checkpoint, top stretch) had `h=40`, putting its bottom boundary at `y=48` — exactly where the finish tile begins. A player going east at `py=48` (the natural low racing line through the top-right corner) failed the `py < 48` check, skipped CP3, crossed the finish with `cps_ok=0`, and the lap silently dropped. Fixed by extending `h` from `40` to `56` (`y=8–64`), covering the full finish-tile height. Proven with two headless regression tests.

## Test plan

- [x] `make test` — all tests pass (0 failures), including:
  - 4 new `pos_from_manhattan` tests in `test_state_playing.c`
  - 2 new track2 CP3 boundary regression tests in `test_checkpoint.c`
- [x] `make clean && make` — ROM builds clean, no errors
- [x] Smoketest on Emulicious: track2 race, all 3 laps registered, player able to win

🤖 Generated with [Claude Code](https://claude.com/claude-code)