### PR TITLE
fix(music): decouple music tempo from frame load (VBlank catch-up)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -116,7 +116,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py C:\\Code\\nuke-raider\\tools\\bank_check_hook.py",
+            "command": "py C:/Code/nuke-raider/tools/bank_check_hook.py",
             "statusMessage": "bank-pre-write check..."
           }
         ]
@@ -139,7 +139,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "py C:\\Code\\nuke-raider\\tools\\post_build_hook.py",
+            "command": "py C:/Code/nuke-raider/tools/post_build_hook.py",
             "statusMessage": "bank-post-build + memory-check..."
           }
         ]

--- a/docs/superpowers/plans/2026-06-08-music-tempo-lag.md
+++ b/docs/superpowers/plans/2026-06-08-music-tempo-lag.md
@@ -1,0 +1,424 @@
+# Music Tempo Lag Fix — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans (or subagent-driven-development) to implement this plan task-by-task.
+
+**Goal:** Decouple music tempo from frame load so the song advances at a true 60 ticks/sec regardless of how long a frame takes, eliminating the tempo drag that grows as more entities are added.
+
+**Architecture:** "VBlank-counted catch-up." The VBL ISR only increments a saturating byte counter (`music_ticks_owed`) — no bank switch, so it is interrupt-safe and avoids the documented `SWITCH_ROM`-in-ISR crash. The main loop drains the counter via `music_service()`, running `music_tick()` once per elapsed VBlank (clamped to `MUSIC_MAX_CATCHUP`). Behavior is byte-identical at 60 fps; under load the music stays on-tempo while visuals stutter (the chosen tradeoff). Spec: `docs/superpowers/specs/2026-06-08-music-tempo-lag-design.md`.
+
+**Tech Stack:** GBDK-2020, SDCC, hUGEDriver, Unity (host tests via gcc).
+
+## Open questions (must resolve before starting)
+
+- None. Design validated by `music-expert`; resync coverage and helper double-tick resolved during grill-me (see spec + plan notes below).
+
+---
+
+## Implementation notes (resolved decisions)
+
+- **Helper double-tick fix:** `vbl_sync()` and `vbl_display_off()` keep their **single** direct `music_tick()` (preserves `vbl_display_off`'s tight LCD-off-inside-VBlank timing — routing through `music_service()` could run up to 3 ticks and push the LCD-off write past the VBlank window). Immediately after the tick they **decrement `owed` by one** under `__critical`, so the next `music_service()` does not re-tick that VBlank.
+- **Resync coverage:** `state_playing.enter()` always re-runs on every gameplay (re)entry (`state_manager.c` re-invokes `enter` on push/pop/replace) and always reaches `DISPLAY_ON` (line 121). `music_resync()` after that line covers every race start. No hidden pause/resume path.
+- **`music_ticks_owed`** is one file-scope `static volatile uint8_t` in `music.c` — same allocation pattern as the existing `current_song_bank`; the hUGEDriver-WRAM-collision warning applies only to *static locals* inside `music_tick()`, not file-scope statics.
+- **SFX unchanged:** `sfx_tick()` stays exactly once per frame. Looping it would truncate frame-authored SFX durations.
+
+---
+
+## Batch 1 — Music catch-up (the whole fix)
+
+### Task 1: Music catch-up core + tests (host-testable)
+
+**Files:**
+- Modify: `src/config.h`, `src/music.h`, `src/music.c`
+- Test: `tests/test_music.c`
+
+**Depends on:** none
+**Parallelizable with:** none — Tasks 2 and 3 both compile against symbols this task defines (`music_notify_vblank`, `music_service`, `music_resync`), so it must land first.
+
+**Step 1: Write the failing tests**
+
+In `tests/test_music.c`, add an extern for the mock counter and reset it in `setUp`:
+
+```c
+extern int hUGE_dosound_call_count;   /* tests/mocks/hUGEDriver_mock.c */
+
+void setUp(void) {
+    frame_ready = 0;
+    _current_bank_mock = 0;
+    hUGE_dosound_call_count = 0;
+    music_resync();                   /* zero the catch-up counter between tests */
+}
+```
+
+Add these test functions:
+
+```c
+/* music_service() with one owed VBlank runs exactly one driver tick. */
+void test_music_service_one_owed_runs_one_tick(void) {
+    music_resync();
+    music_notify_vblank();                 /* owed = 1 */
+    hUGE_dosound_call_count = 0;
+    uint8_t ran = music_service();
+    TEST_ASSERT_EQUAL_UINT8(1u, ran);
+    TEST_ASSERT_EQUAL_INT(1, hUGE_dosound_call_count);
+    TEST_ASSERT_EQUAL_UINT8(0u, music_ticks_owed_peek());
+}
+
+/* Three owed VBlanks (within the cap) run three driver ticks. */
+void test_music_service_three_owed_runs_three_ticks(void) {
+    music_resync();
+    music_notify_vblank(); music_notify_vblank(); music_notify_vblank();
+    hUGE_dosound_call_count = 0;
+    uint8_t ran = music_service();
+    TEST_ASSERT_EQUAL_UINT8(3u, ran);
+    TEST_ASSERT_EQUAL_INT(3, hUGE_dosound_call_count);
+    TEST_ASSERT_EQUAL_UINT8(0u, music_ticks_owed_peek());
+}
+
+/* Owed above MUSIC_MAX_CATCHUP clamps the drain but still fully zeroes the counter. */
+void test_music_service_clamps_to_cap(void) {
+    music_resync();
+    for (uint8_t i = 0; i < 10u; i++) music_notify_vblank();
+    hUGE_dosound_call_count = 0;
+    uint8_t ran = music_service();
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)MUSIC_MAX_CATCHUP, ran);
+    TEST_ASSERT_EQUAL_INT((int)MUSIC_MAX_CATCHUP, hUGE_dosound_call_count);
+    TEST_ASSERT_EQUAL_UINT8(0u, music_ticks_owed_peek());
+}
+
+/* The counter saturates at 255 and never wraps to 0. */
+void test_music_notify_saturates_at_255(void) {
+    music_resync();
+    for (uint16_t i = 0; i < 300u; i++) music_notify_vblank();
+    TEST_ASSERT_EQUAL_UINT8(255u, music_ticks_owed_peek());
+}
+
+/* music_resync() zeroes a non-zero counter. */
+void test_music_resync_zeroes_counter(void) {
+    music_notify_vblank(); music_notify_vblank();
+    music_resync();
+    TEST_ASSERT_EQUAL_UINT8(0u, music_ticks_owed_peek());
+}
+
+/* vbl_display_off() ticks exactly once and accounts for the VBlank it consumed,
+ * so a following music_service() will not re-tick it (no double-tick). */
+void test_vbl_display_off_accounts_one_tick(void) {
+    music_resync();
+    music_notify_vblank(); music_notify_vblank();   /* owed = 2 (simulate ISR) */
+    frame_ready = 1;
+    hUGE_dosound_call_count = 0;
+    vbl_display_off();
+    TEST_ASSERT_EQUAL_INT(1, hUGE_dosound_call_count);
+    TEST_ASSERT_EQUAL_UINT8(1u, music_ticks_owed_peek());
+}
+```
+
+Register each in `main()` with `RUN_TEST(...)`. Keep the three existing tests.
+
+**Step 2: Run tests to verify they fail**
+
+Run (from worktree): `make test`
+Expected: FAIL — `music_notify_vblank` / `music_service` / `music_resync` / `music_ticks_owed_peek` undefined.
+
+**Step 3: HARD GATE — bank-pre-write**
+
+Invoke the `bank-pre-write` skill. `src/music.c`, `src/config.h`, `src/music.h` are existing bank-0 artifacts; no new `.c` file, so no `bank-manifest.json` change. Confirm the gate passes before writing.
+
+**Step 4: HARD GATE — gbdk-expert**
+
+Invoke the `gbdk-expert` agent. Confirm: file-scope `static volatile uint8_t` placement is safe; `__critical` snapshot/decrement usage is correct; `music_notify_vblank` stays non-BANKED bank-0; calling `music_resync()` after (not inside) `music_start()`'s `__critical` avoids nested critical sections.
+
+**Step 5: Write the implementation**
+
+`src/config.h` — after the `DEBUG_TICK_ADDR` line (~137):
+
+```c
+/* Music catch-up cap: max music_tick() calls music_service() runs in one frame to
+ * resync tempo after a frame overrun. Bounds the catch-up so a multi-frame stall
+ * cannot spiral or produce an audible fast-forward. Above this, excess ticks drop. */
+#define MUSIC_MAX_CATCHUP 3u
+```
+
+`src/music.h` — after the `music_tick()` declaration (~line 18):
+
+```c
+/* music_notify_vblank() — called ONLY from vbl_isr(). Increments the catch-up
+ * counter (saturating at 255). No bank switch, no hUGEDriver call -> interrupt-safe.
+ * Must stay non-BANKED (bank 0). */
+void music_notify_vblank(void);
+
+/* music_service() — drain the catch-up counter: run music_tick() once per VBlank
+ * elapsed since the last call (clamped to MUSIC_MAX_CATCHUP). Call once per main-
+ * loop iteration in place of music_tick(). Returns the number of ticks run. */
+uint8_t music_service(void);
+
+/* music_resync() — zero the catch-up counter. Call on gameplay resume / LCD-on
+ * (state_playing enter) and inside music_start(), so accumulated backlog does not
+ * drain as an audible catch-up burst at a transition. */
+void music_resync(void);
+
+/* music_ticks_owed_peek() — test-visible read of the catch-up counter. */
+uint8_t music_ticks_owed_peek(void);
+```
+
+`src/music.c`:
+- Add `#include "config.h"` near the top (debug.h only includes it under `#ifdef DEBUG`).
+- Add module state beside `current_song_bank` (~line 19): `static volatile uint8_t music_ticks_owed = 0u;`
+- Add the four new functions:
+
+```c
+void music_notify_vblank(void) {
+    if (music_ticks_owed < 255u) music_ticks_owed++;
+}
+
+uint8_t music_service(void) {
+    uint8_t owed;
+    __critical { owed = music_ticks_owed; music_ticks_owed = 0u; }
+    if (owed > MUSIC_MAX_CATCHUP) owed = MUSIC_MAX_CATCHUP;
+    for (uint8_t i = 0u; i < owed; i++) {
+        music_tick();
+    }
+    return owed;
+}
+
+void music_resync(void) {
+    __critical { music_ticks_owed = 0u; }
+}
+
+uint8_t music_ticks_owed_peek(void) {
+    return music_ticks_owed;
+}
+```
+
+- In `music_start()`, add `music_resync();` as the last line (AFTER the existing `__critical` block closes — do not nest):
+
+```c
+void music_start(uint8_t bank, const hUGESong_t *song) {
+    current_song_bank = bank;
+    __critical {
+        uint8_t _saved_bank = CURRENT_BANK;
+        SWITCH_ROM(bank);
+        hUGE_init(song);
+        SWITCH_ROM(_saved_bank);
+    }
+    music_resync();   /* fresh song has no backlog to honor */
+}
+```
+
+- Update the two helpers to tick once and account for the consumed VBlank:
+
+```c
+void vbl_sync(void) {
+    while (!frame_ready);
+    frame_ready = 0;
+    music_tick();
+    __critical { if (music_ticks_owed) music_ticks_owed--; }
+}
+
+void vbl_display_off(void) {
+    while (!frame_ready);
+    frame_ready = 0;
+    music_tick();
+    __critical { if (music_ticks_owed) music_ticks_owed--; }
+    LCDC_REG &= ~0x80U;
+}
+```
+
+`music_tick()` itself is UNCHANGED.
+
+**Step 6: Run tests to verify they pass**
+
+Run: `make test`
+Expected: PASS (all new + 3 existing music tests).
+
+**Step 7: HARD GATE — build**
+
+Invoke the `build` skill (or `make`). Expected: ROM at `build/nuke-raider.gb`, zero errors.
+
+**Step 8: HARD GATE — bank-post-build**
+
+Invoke the `bank-post-build` skill. Confirm `src/music.c` stays in bank 0 and ROM/bank budgets are within limits.
+
+**Step 9: Refactor checkpoint**
+
+"Breaks when N > 1?" — The counter is a single scalar; catch-up is bounded by the config cap. No hard-coded entity assumptions. Proceed.
+
+**Step 10: HARD GATE — gb-c-optimizer (validate only)**
+
+Invoke the `gb-c-optimizer` agent on `src/music.c`. Validate only; report issues (do not apply now).
+
+**Step 11: Commit**
+
+```bash
+git add src/config.h src/music.h src/music.c tests/test_music.c
+git commit -m "feat(music): VBlank-counted catch-up ticks (music_service/notify/resync)"
+```
+
+---
+
+### Task 2: Wire catch-up into the VBL ISR and main loop
+
+**Files:**
+- Modify: `src/main.c`
+
+**Depends on:** Task 1 (uses `music_notify_vblank`, `music_service`)
+**Parallelizable with:** Task 3 — different file (`state_playing.c`), no shared symbols defined by either.
+
+**Step 1: Write the failing test** — N/A. `src/main.c` is excluded from the host test build (`TEST_LIB_SRC := $(filter-out src/main.c,...)`). Verified by build + Smoketest Checkpoint 1.
+
+**Step 2: Run test to verify it fails** — N/A (see Step 1).
+
+**Step 3: HARD GATE — bank-pre-write**
+
+Invoke `bank-pre-write`. `src/main.c` is an existing bank-0 artifact; no manifest change.
+
+**Step 4: HARD GATE — gbdk-expert**
+
+Invoke `gbdk-expert`. Confirm `music_notify_vblank()` is safe to call from `vbl_isr` (no bank switch, no hUGEDriver call) and that replacing `music_tick()` with `music_service()` in the loop is correct.
+
+**Step 5: Write the implementation**
+
+In `vbl_isr()` (currently main.c:39-42), add the counter increment:
+
+```c
+static void vbl_isr(void) {
+    move_bkg(cam_scx_shadow, cam_scy_shadow);  /* apply shadow SCX/SCY at VBlank start */
+    music_notify_vblank();                      /* count this VBlank (no bank switch — ISR-safe) */
+    frame_ready = 1;
+}
+```
+
+In the main loop (currently main.c:61-68), replace the single `music_tick()` with `music_service()`; `sfx_tick()` stays once:
+
+```c
+    while (1) {
+        while (!frame_ready);
+        frame_ready = 0;
+        music_service();          /* catch up music for every elapsed VBlank */
+        sfx_tick();               /* exactly once per frame */
+        input_update();
+        state_manager_update();
+    }
+```
+
+(`main.c` already `#include "music.h"`.)
+
+**Step 6: Run tests** — `make test`. Expected: PASS (unchanged from Task 1; main.c not tested).
+
+**Step 7: HARD GATE — build** — `make`. Expected: ROM, zero errors.
+
+**Step 8: HARD GATE — bank-post-build** — invoke `bank-post-build`.
+
+**Step 9: Refactor checkpoint** — no hard-coded N. Proceed.
+
+**Step 10: HARD GATE — gb-c-optimizer (validate only)** — run on `src/main.c`, report only.
+
+**Step 11: Commit**
+
+```bash
+git add src/main.c
+git commit -m "feat(music): drive catch-up from VBL ISR + main loop music_service()"
+```
+
+---
+
+### Task 3: Resync on gameplay entry
+
+**Files:**
+- Modify: `src/state_playing.c`
+
+**Depends on:** Task 1 (uses `music_resync`)
+**Parallelizable with:** Task 2 — different file (`main.c`), no shared symbols.
+
+**Step 1: Write the failing test** — N/A. `state_playing.enter()` LCD/transition behavior is not host-unit-tested; verified by Smoketest Checkpoint 1.
+
+**Step 2: Run test to verify it fails** — N/A (see Step 1).
+
+**Step 3: HARD GATE — bank-pre-write**
+
+Invoke `bank-pre-write`. `src/state_playing.c` is an existing banked artifact already in the manifest; no manifest change.
+
+**Step 4: HARD GATE — gbdk-expert**
+
+Invoke `gbdk-expert`. Confirm calling `music_resync()` (a bank-0 function) from banked `state_playing.c` `enter()` is safe (it is invoked via the state manager's `invoke()` trampoline, like all other bank-0 calls here), and that `#include "music.h"` is present (add if missing).
+
+**Step 5: Write the implementation**
+
+In `state_playing.c` `enter()`, add `music_resync()` immediately after `DISPLAY_ON;` (currently line 121):
+
+```c
+    DISPLAY_ON;
+    music_resync();   /* zero catch-up backlog so the race start does not burp */
+}
+```
+
+Ensure `#include "music.h"` is in the file's includes; add it if absent.
+
+**Step 6: Run tests** — `make test`. Expected: PASS (unchanged).
+
+**Step 7: HARD GATE — build** — `make`. Expected: ROM, zero errors.
+
+**Step 8: HARD GATE — bank-post-build** — invoke `bank-post-build`.
+
+**Step 9: Refactor checkpoint** — single call, no N. Proceed.
+
+**Step 10: HARD GATE — gb-c-optimizer (validate only)** — run on `src/state_playing.c`, report only.
+
+**Step 11: Commit**
+
+```bash
+git add src/state_playing.c
+git commit -m "feat(music): resync catch-up counter on gameplay entry"
+```
+
+---
+
+#### Parallel Execution Groups — Smoketest Checkpoint 1
+
+| Group | Tasks | Notes |
+|-------|-------|-------|
+| A (sequential, first) | Task 1 | Defines `music_notify_vblank` / `music_service` / `music_resync`; host-testable core. Must complete before B. |
+| B (parallel) | Task 2, Task 3 | Different files (`main.c`, `state_playing.c`); both depend only on Task 1; neither uses a symbol the other defines. |
+
+### Smoketest Checkpoint 1 — music holds tempo under load; transitions and SFX clean
+
+**Step 1: Fetch and merge latest master (from worktree directory)**
+```bash
+git fetch origin && git merge origin/master
+```
+
+**Step 2: Clean build**
+```bash
+make clean && make
+```
+Expected: ROM at `build/nuke-raider.gb`, zero errors.
+
+**Step 3: Memory check**
+```bash
+make memory-check
+```
+Expected: all budgets PASS. Fix any FAIL/ERROR before continuing.
+
+**Step 4: Launch ROM (run from worktree directory — use PowerShell tool, not Bash)**
+```powershell
+Start-Process -FilePath "java" -ArgumentList "-jar", "C:\Tools\Emulicious\Emulicious.jar", "build\nuke-raider.gb" -PassThru
+```
+
+**Step 5: Confirm with user.** Verify:
+- Title/overmap/hub music plays at normal tempo and pitch (no change vs before).
+- Start a race and drive into the busiest part of the track (multiple racers/turrets/projectiles on screen). **The music tempo stays steady — it must NOT drag/slow down** as the action gets heavy. Visual stutter under heavy load is acceptable and expected.
+- Hub menu/dialog transitions (which use `vbl_display_off`) sound normal — no speed-up or stutter in the music during menu re-renders.
+- Fire weapons and take hits — SFX play at normal length (not cut short), and music is unaffected.
+
+Wait for explicit user confirmation before finishing the branch.
+
+---
+
+## Plan Self-Review
+
+| # | Check | Result |
+|---|-------|--------|
+| 1 | No hardcoded values | PASS — catch-up bound is `MUSIC_MAX_CATCHUP` in `config.h`; `255` is the inherent `uint8_t` saturation ceiling. |
+| 2 | All tasks have test criteria | PASS — Task 1 has `make test` assertions; Tasks 2/3 have build + explicit smoketest checks (and document why no host test). |
+| 3 | Parallel annotations justified | PASS — Task 1 `none` justified (defines shared symbols); Tasks 2/3 parallelizable, justified (different files, no shared symbols). |
+| 4 | Parallel Execution Groups table present | PASS — table precedes the checkpoint. |
+| 5 | No design narrative leaked | PASS — rationale lives in the spec; plan carries file paths, code, and steps. |

--- a/docs/superpowers/specs/2026-06-08-music-tempo-lag-design.md
+++ b/docs/superpowers/specs/2026-06-08-music-tempo-lag-design.md
@@ -1,0 +1,190 @@
+# Design: Fix frame-rate-coupled music tempo lag
+
+**Date:** 2026-06-08
+**Status:** Approved (design), pending implementation plan
+**Validated by:** `music-expert` agent (consultation)
+
+## Problem
+
+As more entities (enemy racers, turrets, projectiles, powerups) are added, the
+music tempo audibly **drags** — the song plays slower the busier the frame gets.
+
+### Root cause: music is frame-locked
+
+`music_tick()` -> `hUGE_dosound()` is called **once per frame from the main loop**
+(`src/main.c:64`), after `while (!frame_ready); frame_ready = 0;`. hUGEDriver's
+tempo *is* its tick rate: it expects to be advanced once every 16.7 ms (60 Hz).
+
+When `state_manager_update()` (the per-frame entity loop, `src/state_playing.c`)
+overruns the 16.7 ms frame budget, the main loop misses VBlanks. The next
+`music_tick()` therefore fires late, and the song advances slower than wall-clock.
+The tempo is chained behind game logic, so **every feature added re-opens the gap.**
+
+Confirmed symptom: tempo slows/drags (not stutter, not dropout) — textbook
+frame-rate coupling.
+
+## Goal and chosen tradeoff
+
+Decouple music tempo from frame load so the song advances at a true 60 ticks/sec
+regardless of how long a frame takes.
+
+When the game is genuinely overloaded, **something must give**. The chosen tradeoff:
+**music stays perfectly on-tempo; the visuals stutter** (game logic runs at whatever
+framerate it can hit). This is the standard action-game choice — a dropped frame is
+barely noticeable, a wobbling soundtrack is glaring.
+
+## Why not move the tick into the VBlank ISR
+
+The "obvious" fix — call `hUGE_dosound()` directly from the VBL interrupt — is
+**explicitly forbidden in this project** and documented as a crash source
+(`.claude/agents/music-expert.md`):
+
+> Calling `music_tick()` inside `vbl_isr()` — `SWITCH_ROM` inside an ISR corrupts
+> MBC shadow state, causing crashes after several deep BANKED call sequences.
+
+`music_tick()` does a bank switch (`SWITCH_ROM`) to reach the song data. If the
+interrupt fires while the main loop is mid banked-function-call trampoline, the
+bank-shadow variable and the MBC hardware desync, and the ISR's restore corrupts it.
+The crash surfaces much later, after many state transitions. This approach trades a
+music-lag bug for an intermittent-crash bug and is **rejected**.
+
+## Chosen design: VBlank-counted catch-up ticks
+
+The interrupt never enters the audio engine and never switches banks. It does one
+cheap, safe thing: count elapsed VBlanks. The main loop drains that count, running
+the music tick once per elapsed VBlank to catch up.
+
+### Data flow
+
+```
+VBlank fires (60 Hz, LCD on)
+  - vbl_isr:  move_bkg(scroll)             <- unchanged
+              music_notify_vblank()         <- NEW: music_ticks_owed++  (1 byte, no bank switch, no hUGE call)
+              frame_ready = 1               <- unchanged
+
+Main loop, each iteration:
+  while (!frame_ready);  frame_ready = 0;   <- unchanged game-logic pacing
+  owed = music_service();                    <- NEW: snapshot+zero counter, run music_tick() that many times
+  sfx_tick();                                <- UNCHANGED: exactly once per real frame
+  input_update();  state_manager_update();   <- unchanged
+```
+
+### Module API (all state encapsulated in `src/music.c`)
+
+```c
+/* music.c - new module-static state */
+static volatile uint8_t music_ticks_owed;   /* VBlanks elapsed since last service */
+
+/* Called from vbl_isr() ONLY. Non-BANKED, bank 0. No SWITCH_ROM, no hUGE call.
+ * Saturates at 255 so the byte never wraps to 0 and falsely signals "no work". */
+void music_notify_vblank(void) {
+    if (music_ticks_owed < 255u) music_ticks_owed++;
+}
+
+/* Called from the main loop, replacing the single music_tick() call.
+ * Snapshot+zero under __critical (atomic vs the ISR ++), clamp the LOCAL copy,
+ * then advance the driver that many ticks. Returns ticks actually run. */
+uint8_t music_service(void) {
+    uint8_t owed;
+    __critical { owed = music_ticks_owed; music_ticks_owed = 0u; }
+    if (owed > MUSIC_MAX_CATCHUP) owed = MUSIC_MAX_CATCHUP;
+    for (uint8_t i = 0u; i < owed; i++) music_tick();
+    return owed;
+}
+
+/* Zero the backlog under __critical. Call when gameplay resumes / LCD turns back
+ * on, and inside music_start(), so a transition doesn't trigger a catch-up burst. */
+void music_resync(void) {
+    __critical { music_ticks_owed = 0u; }
+}
+```
+
+`music_tick()` itself is **unchanged** — it keeps its own `__critical` + bank
+save/`SWITCH_ROM`/`hUGE_dosound`/restore. Calling it N times back-to-back from
+`music_service()` is fine: the critical sections are sequential, not nested.
+
+### Key properties
+
+1. **Tempo cannot drag.** Over any window, exactly one music tick runs per elapsed
+   VBlank. Average tempo is locked to wall-clock no matter how slow a frame is.
+2. **Zero change at 60 fps.** When not overloaded, `owed` is always 1 — byte-for-byte
+   identical to today's behavior. The fix only engages on an actual overrun.
+3. **ISR is bank-safe.** It only does a saturating byte increment — no `SWITCH_ROM`,
+   no hUGE call, no BANKED trampoline. The documented crash hazard cannot occur.
+4. **SFX is untouched.** Because the ISR never enters hUGEDriver, there are no new
+   races with `sfx_play`/`sfx_tick`/`music_start`. SFX timing is unchanged.
+
+### Catch-up cap
+
+`MUSIC_MAX_CATCHUP` in `src/config.h`, **default 3**. Bounds the drain so a
+multi-frame stall can't spiral and can't produce a long audible "fast-forward".
+Above the cap, excess ticks are dropped (the only case where tiny drift returns —
+well beyond any playable framerate). Per project rules this cap is explicit, tunable,
+and documented — not a silent truncation.
+
+Trade-off note (from `music-expert`): when catching up N ticks in <1 ms,
+`hUGE_dosound()` advances N rows' worth of state near-instantly; intermediate note
+triggers are overwritten by the last tick, producing a brief catch-up glitch instead
+of a tempo drag. A small cap (2-3) keeps this imperceptible while still resyncing.
+
+## Edge cases
+
+### LCD-off transitions (`vbl_sync`, `vbl_display_off`)
+
+With the LCD off, the VBlank interrupt does **not** fire, so `music_ticks_owed`
+stops incrementing — no runaway during loads. The hazard is the *boundary*: a stale
+`owed` accumulated just before a transition would drain as a catch-up burst exactly
+when a state changes (visually busy, worst place for it).
+
+**Resolution:** call `music_resync()` when gameplay resumes / the LCD turns back on,
+and inside `music_start()` (a fresh song has no backlog to honor). The cap alone
+prevents a hang; only the explicit reset prevents the spurious burst.
+
+`vbl_sync()` / `vbl_display_off()` keep their direct `music_tick()` call (explicit
+single-tick paths around LCD transitions). The implementation plan must **audit
+their callers** (currently `state_hub.c` uses `vbl_display_off()` in 4 places;
+`main.c` does not call `vbl_sync()`) to confirm no double-ticking, with
+`music_resync()` on resume as the backstop.
+
+### DEBUG tick counter
+
+`music_tick()` calls `DBG_TICK_INC()`. Under catch-up this counts *driver ticks*,
+not *frames*, so any diagnostic/test asserting "tick count == frame count" would
+break under overrun. The plan must verify `test_music*` and DEBUG diagnostics don't
+assume a 1:1 frame:tick ratio.
+
+## Files impacted
+
+- `src/music.c` — add `music_ticks_owed`, `music_notify_vblank()`, `music_service()`,
+  `music_resync()`. `music_tick()` unchanged. `music_start()` calls `music_resync()`.
+- `src/music.h` — declare the three new functions.
+- `src/main.c` — `vbl_isr()` calls `music_notify_vblank()`; main loop replaces
+  `music_tick();` with `music_service();` (keeps `sfx_tick()` once per frame).
+- `src/config.h` — add `MUSIC_MAX_CATCHUP` (default 3).
+- `src/state_playing.c` (or wherever gameplay resumes / LCD turns on) — call
+  `music_resync()` on entry/resume.
+- `tests/test_music.c` — new tests (below).
+
+All of `src/music.c`, `src/sfx.c`, `src/main.c` stay in **bank 0** (home bank);
+`music_notify_vblank()` must be non-`BANKED`. No `bank-manifest.json` change (no new
+files).
+
+## Testing (TDD)
+
+`music_service()` is a pure, host-testable function; `tests/test_music.c` already
+mocks hUGEDriver. New tests:
+
+- `owed = 1` -> `music_service()` runs exactly one tick, returns 1, counter ends at 0.
+- `owed = 3` -> runs three ticks, returns 3.
+- `owed > MUSIC_MAX_CATCHUP` -> clamps to the cap, counter still fully zeroed.
+- `music_notify_vblank()` saturates at 255 (does not wrap to 0).
+- `music_resync()` zeros a non-zero counter.
+- `music_service()` snapshot-and-zero leaves the counter at 0 after the call.
+- Regression: at `owed = 1` behavior matches the pre-change single-tick path.
+
+## Out of scope
+
+- Optimizing the entity loop to reduce overruns (a separate, complementary follow-up
+  that would shrink the *visual* stutter; not required for the music fix).
+- Any change to hUGEDriver, song data, or the SFX engine.
+- Moving `sfx_tick()` to catch-up (rejected — would truncate frame-authored SFX).

--- a/src/config.h
+++ b/src/config.h
@@ -129,6 +129,11 @@
 #define PROJ_MAX_TTL          60u   /* max frames alive; safety cap (~full-screen diagonal at PROJ_SPEED=4) */
 #define PROJ_FIRE_COOLDOWN    8u    /* frames between shots (held Select = 60/8 = ~7.5 shots/sec) */
 
+/* Music catch-up cap: max music_tick() calls music_service() runs in one frame to
+ * resync tempo after a frame overrun. Bounds the catch-up so a multi-frame stall
+ * cannot spiral or produce an audible fast-forward. Above this, excess ticks drop. */
+#define MUSIC_MAX_CATCHUP 3u
+
 /* Debug ring buffer — EMU_printf / Emulicious debug output (DEBUG=1 only).
  * Fixed WRAM addresses in the last 66 bytes — well above static data (~0xC000-0xC242). */
 #define DEBUG_LOG_ADDR    0xDF80U  /* WRAM: ring buffer content (64 bytes) */

--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,7 @@ volatile uint8_t frame_ready = 0;
 
 static void vbl_isr(void) {
     move_bkg(cam_scx_shadow, cam_scy_shadow);  /* apply shadow SCX/SCY at VBlank start */
+    music_notify_vblank();                      /* count this VBlank (no bank switch - ISR safe) */
     frame_ready = 1;
 }
 
@@ -61,7 +62,7 @@ void main(void) {
     while (1) {
         while (!frame_ready);
         frame_ready = 0;
-        music_tick();
+        music_service();          /* catch up music for every elapsed VBlank */
         sfx_tick();
         input_update();           /* saves prev frame, reads joypad() */
         state_manager_update();

--- a/src/music.c
+++ b/src/music.c
@@ -11,12 +11,14 @@
 #include <gb/gb.h>
 #include <gb/hardware.h>
 #include "banking.h"
+#include "config.h"
 #include "hUGEDriver.h"
 #include "music_data.h"
 #include "music.h"
 #include "debug.h"
 
 static uint8_t current_song_bank = 0;
+static volatile uint8_t music_ticks_owed = 0u;
 
 void music_init(void) {
     NR52_REG = 0x80;  /* enable APU */
@@ -38,6 +40,7 @@ void music_start(uint8_t bank, const hUGESong_t *song) {
         hUGE_init(song);
         SWITCH_ROM(_saved_bank);
     }
+    music_resync();   /* fresh song has no backlog to honor */
 }
 
 void music_tick(void) {
@@ -53,15 +56,40 @@ void music_tick(void) {
     }
 }
 
+void music_notify_vblank(void) {
+    if (music_ticks_owed < 255u) music_ticks_owed++;
+}
+
+uint8_t music_service(void) {
+    uint8_t owed;
+    uint8_t i;
+    __critical { owed = music_ticks_owed; music_ticks_owed = 0u; }
+    if (owed > MUSIC_MAX_CATCHUP) owed = MUSIC_MAX_CATCHUP;
+    for (i = 0u; i < owed; i++) {
+        music_tick();
+    }
+    return owed;
+}
+
+void music_resync(void) {
+    __critical { music_ticks_owed = 0u; }
+}
+
+uint8_t music_ticks_owed_peek(void) {
+    return music_ticks_owed;
+}
+
 void vbl_sync(void) {
     while (!frame_ready);
     frame_ready = 0;
     music_tick();
+    __critical { if (music_ticks_owed) music_ticks_owed--; }
 }
 
 void vbl_display_off(void) {
     while (!frame_ready);      /* wait for VBlank start */
     frame_ready = 0;
     music_tick();              /* tick music for this VBlank */
-    LCDC_REG &= ~0x80U;       /* disable LCD — safe: we're in VBlank */
+    __critical { if (music_ticks_owed) music_ticks_owed--; }  /* account for this VBlank so music_service wont re-tick it */
+    LCDC_REG &= ~0x80U;        /* disable LCD - safe: we are in VBlank */
 }

--- a/src/music.h
+++ b/src/music.h
@@ -17,6 +17,24 @@ void music_start(uint8_t bank, const hUGESong_t *song);
  * in the main loop (not from vbl_isr). */
 void music_tick(void);
 
+/* music_notify_vblank() — called ONLY from vbl_isr(). Increments the catch-up
+ * counter (saturating at 255). No bank switch, no hUGEDriver call -> interrupt-safe.
+ * Must stay non-BANKED (bank 0). */
+void music_notify_vblank(void);
+
+/* music_service() — drain the catch-up counter: run music_tick() once per VBlank
+ * elapsed since the last call (clamped to MUSIC_MAX_CATCHUP). Call once per main-
+ * loop iteration in place of music_tick(). Returns the number of ticks run. */
+uint8_t music_service(void);
+
+/* music_resync() — zero the catch-up counter. Call on gameplay resume / LCD-on
+ * (state_playing enter) and inside music_start(), so accumulated backlog does not
+ * drain as an audible catch-up burst at a transition. */
+void music_resync(void);
+
+/* music_ticks_owed_peek() — test-visible read of the catch-up counter. */
+uint8_t music_ticks_owed_peek(void);
+
 /* vbl_sync() — wait for the next VBlank (via frame_ready flag), then call
  * music_tick(). Use this instead of wait_vbl_done() in any state that needs
  * to block until VBlank — it ensures music never misses a tick. */

--- a/src/state_playing.c
+++ b/src/state_playing.c
@@ -20,6 +20,7 @@ BANKREF_EXTERN(state_playing)
 #include "turret.h"
 #include "racer.h"
 #include "sfx.h"
+#include "music.h"
 #include "powerup.h"
 #include "config.h"
 
@@ -119,6 +120,7 @@ static void enter(void) {
         set_bkg_tiles(cd_bg_col, cd_bg_row, 2u, 1u, cd_init_tiles);
     }
     DISPLAY_ON;
+    music_resync();   /* zero catch-up backlog so the race start does not burp */
 }
 
 static void update(void) {

--- a/tests/test_music.c
+++ b/tests/test_music.c
@@ -1,8 +1,15 @@
 #include "unity.h"
 #include "music.h"
 #include "music_data.h"
+#include "config.h"
+extern int hUGE_dosound_call_count;  /* tests/mocks/hUGEDriver_mock.c */
 
-void setUp(void)    { frame_ready = 0; _current_bank_mock = 0; }
+void setUp(void) {
+    frame_ready = 0;
+    _current_bank_mock = 0;
+    hUGE_dosound_call_count = 0;
+    music_resync();
+}
 void tearDown(void) {}
 
 /* vbl_display_off() should consume the frame_ready flag (set it to 0).
@@ -30,10 +37,82 @@ void test_music_data_order_cnt_is_136(void) {
     TEST_ASSERT_EQUAL_UINT8(136u, *music_data_song.order_cnt);
 }
 
+/* music_service() with one owed VBlank runs exactly one driver tick. */
+void test_music_service_one_owed_runs_one_tick(void) {
+    music_resync();
+    music_notify_vblank();                 /* owed = 1 */
+    hUGE_dosound_call_count = 0;
+    {
+        uint8_t ran = music_service();
+        TEST_ASSERT_EQUAL_UINT8(1u, ran);
+    }
+    TEST_ASSERT_EQUAL_INT(1, hUGE_dosound_call_count);
+    TEST_ASSERT_EQUAL_UINT8(0u, music_ticks_owed_peek());
+}
+
+/* Three owed VBlanks (within the cap) run three driver ticks. */
+void test_music_service_three_owed_runs_three_ticks(void) {
+    music_resync();
+    music_notify_vblank(); music_notify_vblank(); music_notify_vblank();
+    hUGE_dosound_call_count = 0;
+    {
+        uint8_t ran = music_service();
+        TEST_ASSERT_EQUAL_UINT8(3u, ran);
+    }
+    TEST_ASSERT_EQUAL_INT(3, hUGE_dosound_call_count);
+    TEST_ASSERT_EQUAL_UINT8(0u, music_ticks_owed_peek());
+}
+
+/* Owed above MUSIC_MAX_CATCHUP clamps the drain but still fully zeroes the counter. */
+void test_music_service_clamps_to_cap(void) {
+    uint8_t k;
+    music_resync();
+    for (k = 0u; k < 10u; k++) music_notify_vblank();
+    hUGE_dosound_call_count = 0;
+    {
+        uint8_t ran = music_service();
+        TEST_ASSERT_EQUAL_UINT8((uint8_t)MUSIC_MAX_CATCHUP, ran);
+    }
+    TEST_ASSERT_EQUAL_INT((int)MUSIC_MAX_CATCHUP, hUGE_dosound_call_count);
+    TEST_ASSERT_EQUAL_UINT8(0u, music_ticks_owed_peek());
+}
+
+/* The counter saturates at 255 and never wraps to 0. */
+void test_music_notify_saturates_at_255(void) {
+    uint16_t k;
+    music_resync();
+    for (k = 0u; k < 300u; k++) music_notify_vblank();
+    TEST_ASSERT_EQUAL_UINT8(255u, music_ticks_owed_peek());
+}
+
+/* music_resync() zeroes a non-zero counter. */
+void test_music_resync_zeroes_counter(void) {
+    music_notify_vblank(); music_notify_vblank();
+    music_resync();
+    TEST_ASSERT_EQUAL_UINT8(0u, music_ticks_owed_peek());
+}
+
+/* vbl_display_off() ticks exactly once and accounts for the VBlank it consumed,
+ * so a following music_service() will not re-tick it (no double-tick). */
+void test_vbl_display_off_accounts_one_tick(void) {
+    music_resync();
+    music_notify_vblank(); music_notify_vblank();   /* owed = 2 (simulate ISR) */
+    frame_ready = 1;
+    hUGE_dosound_call_count = 0;
+    vbl_display_off();
+    TEST_ASSERT_EQUAL_INT(1, hUGE_dosound_call_count);
+    TEST_ASSERT_EQUAL_UINT8(1u, music_ticks_owed_peek());
+}
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_vbl_display_off_consumes_frame_ready);
     RUN_TEST(test_music_tick_restores_bank);
     RUN_TEST(test_music_data_order_cnt_is_136);
+    RUN_TEST(test_music_service_one_owed_runs_one_tick);
+    RUN_TEST(test_music_service_three_owed_runs_three_ticks);
+    RUN_TEST(test_music_service_clamps_to_cap);
+    RUN_TEST(test_music_notify_saturates_at_255);
+    RUN_TEST(test_music_resync_zeroes_counter);
+    RUN_TEST(test_vbl_display_off_accounts_one_tick);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- Fixes frame-rate-coupled music tempo lag: the song no longer drags as more entities (racers, turrets, projectiles) are added.
- Mechanism — "VBlank-counted catch-up": the VBL ISR only increments a saturating byte counter (`music_notify_vblank`, no bank switch → ISR-safe, respecting the documented `SWITCH_ROM`-in-ISR crash rule). The main loop drains it via `music_service()`, running `music_tick()` once per elapsed VBlank (clamped to `MUSIC_MAX_CATCHUP=3`). Tempo is locked to wall-clock; behavior is byte-identical at 60 fps. Chosen tradeoff: music stays perfect, visuals stutter under heavy load.
- `music_resync()` zeroes the backlog on gameplay entry and on song start so transitions don't produce a catch-up burst; `vbl_sync`/`vbl_display_off` tick once and decrement the counter to avoid double-ticking (preserves `vbl_display_off`'s LCD-off-in-VBlank timing). `sfx_tick()` stays exactly once per frame.
- Also fixes a Windows hook bug: `bank_check_hook.py` / `post_build_hook.py` command paths now use forward slashes (POSIX-shell backslash stripping was mangling the path and blocking every Write/Edit and Bash build).

Spec: `docs/superpowers/specs/2026-06-08-music-tempo-lag-design.md`
Plan: `docs/superpowers/plans/2026-06-08-music-tempo-lag.md`

## Test Plan
- [x] `make test` — 9/9 `test_music` tests pass (6 new: one/three owed ticks, clamp-to-cap, saturate-at-255, resync-zeroes, vbl_display_off-accounts-one-tick)
- [x] Emulicious smoketest confirmed by user — music holds tempo in the busiest part of a race; transitions and SFX clean; no regression
- [x] bank gate: `bank_check` all 44 files match manifest; autobank link OK (no overflow); `romusage` home bank 92% / 8% free
- [x] gb-memory-validator: WRAM 15% / VRAM 19% / OAM 77% — all PASS
- [x] gbdk-expert + gb-c-optimizer reviews — both approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)