### PR TITLE
Patrol PR3: lazy racer OAM + MAX_SPRITES 28->32

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -5,8 +5,9 @@
  * not AoS (struct arrays). See CLAUDE.md "Entity management" for rationale. */
 
 #define MAX_NPCS     8
-/* OAM budget: player=4, dialog_arrow=1 (fixed), projectiles≤8, turrets≤8; hardware cap=40 */
-#define MAX_SPRITES  28
+/* OAM budget: player=4, dialog_arrow=1 (fixed), projectiles≤8, turrets≤8, racer pool (lazy,
+ * ≤8 = 2 active enemies × 4) + patrol=4 (PR4). 32 + 3 fixed = 35 ≤ hardware cap 40. */
+#define MAX_SPRITES  32
 
 /* OAM slot assignments (fixed HUD sprites — after player's 4 pool slots 0-3) */
 #define DIALOG_ARROW_OAM_SLOT      4u  /* OAM slot 4 — hub dialog overflow indicator */

--- a/src/racer.c
+++ b/src/racer.c
@@ -169,10 +169,12 @@ void racer_init(uint8_t tile_base) BANKED {
         racer_hp[i]           = (uint8_t)RACER_HP;
         racer_hit_flash[i]    = 0u;
         racer_finish_armed[i] = 1u;
-        racer_oam[i * 4u + 0u] = get_sprite();
-        racer_oam[i * 4u + 1u] = get_sprite();
-        racer_oam[i * 4u + 2u] = get_sprite();
-        racer_oam[i * 4u + 3u] = get_sprite();
+        /* Lazy OAM: inactive slots hold the sentinel; handles are claimed below
+         * only when the slot becomes active. Reclaims all 12 slots on Track 1. */
+        racer_oam[i * 4u + 0u] = SPRITE_POOL_INVALID;
+        racer_oam[i * 4u + 1u] = SPRITE_POOL_INVALID;
+        racer_oam[i * 4u + 2u] = SPRITE_POOL_INVALID;
+        racer_oam[i * 4u + 3u] = SPRITE_POOL_INVALID;
     }
     s_tile_base  = tile_base;
 
@@ -192,6 +194,11 @@ void racer_init(uint8_t tile_base) BANKED {
             racer_py[i] = (int16_t)((uint16_t)spawn_ty * 8u);
             racer_wp_idx[i] = 0u;
             racer_dir[i] = track_get_start_dir();
+            /* Lazy OAM: claim 4 sprite handles now that the slot is active. */
+            racer_oam[i * 4u + 0u] = get_sprite();
+            racer_oam[i * 4u + 1u] = get_sprite();
+            racer_oam[i * 4u + 2u] = get_sprite();
+            racer_oam[i * 4u + 3u] = get_sprite();
         }
     }
 
@@ -232,7 +239,10 @@ void racer_hide(void) BANKED {
     uint8_t j;
     for (i = 0u; i < MAX_RACERS; i++) {
         for (j = 0u; j < 4u; j++) {
-            move_sprite(racer_oam[i * 4u + j], 0u, 0u);
+            uint8_t h = racer_oam[i * 4u + j];
+            if (h != SPRITE_POOL_INVALID) {
+                move_sprite(h, 0u, 0u);
+            }
         }
     }
 }
@@ -406,6 +416,11 @@ void racer_render(void) BANKED {
         uint8_t hw_y;
         uint8_t d;
         uint8_t flags;
+
+        /* Unallocated slot (lazy OAM): no handles to move. */
+        if (racer_oam[i * 4u + 0u] == SPRITE_POOL_INVALID) {
+            continue;
+        }
 
         if (!racer_active[i]) {
             move_sprite(racer_oam[i * 4u + 0u], 0u, 0u);

--- a/src/sprite_pool.c
+++ b/src/sprite_pool.c
@@ -35,3 +35,14 @@ void clear_sprites_from(uint8_t i) BANKED {
         clear_sprite(j);
     }
 }
+
+#ifndef __SDCC
+uint8_t sprite_pool_active_count(void) {
+    uint8_t i;
+    uint8_t n = 0u;
+    for (i = 0u; i < MAX_SPRITES; i++) {
+        if (spr_act[i]) n++;
+    }
+    return n;
+}
+#endif

--- a/src/sprite_pool.h
+++ b/src/sprite_pool.h
@@ -11,4 +11,9 @@ uint8_t get_sprite(void) BANKED;
 void    clear_sprite(uint8_t i) BANKED;
 void    clear_sprites_from(uint8_t i) BANKED;
 
+#ifndef __SDCC
+/* Host-test only: number of currently-claimed pool slots. Zero ROM/WRAM cost on hardware. */
+uint8_t sprite_pool_active_count(void);
+#endif
+
 #endif /* SPRITE_POOL_H */

--- a/tests/test_racer.c
+++ b/tests/test_racer.c
@@ -6,6 +6,7 @@
 #include "race_state.h"
 #include "player.h"    /* player_dir_t: DIR_T, DIR_B, etc. */
 #include "projectile.h"
+#include "sprite_pool.h"
 
 extern int16_t cam_y;
 
@@ -595,6 +596,48 @@ void test_racer_init_skips_slot_when_no_waypoints(void) {
     TEST_ASSERT_EQUAL_UINT8(0u, racer_active[2]);  /* enemy 1: no waypoints on track0 */
 }
 
+/* === Lazy OAM allocation (PR3) === */
+
+/* Track 0 (track.tmx) has no racers → racer_init must allocate ZERO sprites. */
+void test_racer_init_allocates_no_sprites_when_no_racers(void) {
+    sprite_pool_init();
+    track_test_set_id(0u);
+    racer_init(0u);
+    TEST_ASSERT_EQUAL_UINT8(0u, sprite_pool_active_count());
+}
+
+/* Track 1 (id=1, track2.tmx) has 2 active enemy racers → 2 * 4 = 8 sprites,
+ * NOT 12 (the old unconditional 4 * MAX_RACERS pre-allocation). */
+void test_racer_init_allocates_four_per_active_racer(void) {
+    sprite_pool_init();
+    track_test_set_id(1u);
+    racer_init(0u);
+    TEST_ASSERT_EQUAL_UINT8(8u, sprite_pool_active_count());
+}
+
+/* === Render/hide safe with SPRITE_POOL_INVALID slots (PR3) === */
+
+/* After racer_init on a track with no racers, all OAM handles are INVALID.
+ * racer_hide must NOT call move_sprite on any of them. */
+void test_racer_hide_skips_invalid_slots(void) {
+    sprite_pool_init();
+    track_test_set_id(0u);   /* no racers → all slots INVALID */
+    racer_init(0u);
+    mock_move_sprite_reset();
+    racer_hide();
+    TEST_ASSERT_EQUAL_INT(0, mock_move_sprite_call_count);
+}
+
+/* racer_render with no active racers (all INVALID) must NOT move_sprite. */
+void test_racer_render_skips_invalid_slots(void) {
+    sprite_pool_init();
+    track_test_set_id(0u);
+    racer_init(0u);
+    mock_move_sprite_reset();
+    racer_render();
+    TEST_ASSERT_EQUAL_INT(0, mock_move_sprite_call_count);
+}
+
 void test_racer_rank_with_two_enemies_player_first(void) {
     /* Player (PLAYER_SLOT=0) is 1 lap ahead of both enemies → rank 1.
      * Fails until PLAYER_SLOT=0 and race_state uses correct slot (Tasks 2, 6). */
@@ -659,6 +702,10 @@ int main(void) {
     RUN_TEST(test_racer_init_activates_both_enemy_slots);
     RUN_TEST(test_racer_init_skips_slot_when_no_spawn);
     RUN_TEST(test_racer_init_skips_slot_when_no_waypoints);
+    RUN_TEST(test_racer_init_allocates_no_sprites_when_no_racers);
+    RUN_TEST(test_racer_init_allocates_four_per_active_racer);
+    RUN_TEST(test_racer_hide_skips_invalid_slots);
+    RUN_TEST(test_racer_render_skips_invalid_slots);
     RUN_TEST(test_racer_rank_with_two_enemies_player_first);
     RUN_TEST(test_racer_rank_with_two_enemies_player_last);
     return UNITY_END();

--- a/tests/test_sprite_pool.c
+++ b/tests/test_sprite_pool.c
@@ -81,6 +81,28 @@ void test_clear_sprites_from_zero_frees_all(void) {
     TEST_ASSERT_NOT_EQUAL(SPRITE_POOL_INVALID, get_sprite());
 }
 
+/* --- sprite_pool_active_count (host-test seam) ---------------------- */
+
+/* Fresh pool reports zero active slots */
+void test_active_count_zero_after_init(void) {
+    TEST_ASSERT_EQUAL_UINT8(0u, sprite_pool_active_count());
+}
+
+/* Each get_sprite() increments the active count */
+void test_active_count_tracks_allocations(void) {
+    get_sprite();
+    get_sprite();
+    TEST_ASSERT_EQUAL_UINT8(2u, sprite_pool_active_count());
+}
+
+/* clear_sprite() decrements the active count */
+void test_active_count_decrements_on_clear(void) {
+    uint8_t s0 = get_sprite();
+    get_sprite();
+    clear_sprite(s0);
+    TEST_ASSERT_EQUAL_UINT8(1u, sprite_pool_active_count());
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_init_all_slots_free);
@@ -91,5 +113,8 @@ int main(void) {
     RUN_TEST(test_clear_sprite_hides_sprite);
     RUN_TEST(test_clear_sprites_from_frees_range);
     RUN_TEST(test_clear_sprites_from_zero_frees_all);
+    RUN_TEST(test_active_count_zero_after_init);
+    RUN_TEST(test_active_count_tracks_allocations);
+    RUN_TEST(test_active_count_decrements_on_clear);
     return UNITY_END();
 }


### PR DESCRIPTION
PR3 of the stacked patrol-enemy feature (#144). Frees OAM headroom on Track 1 so PR4''s patrol sprites fit.

## What
- **Lazy racer OAM allocation:** a racer slot claims its 4 sprite handles only when it becomes ACTIVE, instead of the old unconditional pre-allocation of 12 (4 × MAX_RACERS) on every track. Reclaims all 12 wasted slots on racerless Track 1; allocates 8 (2 enemies × 4) on Track 2 instead of 12.
- **`SPRITE_POOL_INVALID` guards** in `racer_render`/`racer_hide` — inactive slots hold the sentinel; both functions skip invalid handles. Fixes a latent bug where `racer_hide` `move_sprite`d every slot unconditionally (could corrupt player OAM slot 0 / pass 0xFF to move_sprite).
- **`MAX_SPRITES` 28 → 32** (hardware OAM cap is 40) for the patrol''s 4 sprites.
- Host-test-only `sprite_pool_active_count()` seam (`#ifndef __SDCC`, zero hardware cost).

## Verification
- `make test` green incl. new tests: zero-alloc on racerless track, 8-alloc (not 12) on a 2-racer track, render/hide issue zero move_sprite calls on INVALID slots; 3 sprite_pool active-count tests. Regression suites unchanged & green.
- Clean ROM build; `bank_check` 46/46 (no new module → no manifest change).
- Spec + quality reviewers approved.
- Smoketest: Track 1 player renders correctly (slot-0 fix), Track 2 racers + P:1/P:2/P:3 HUD correct, overmap↔track transitions clean.

## OAM note
`make memory-check` reports **OAM 35/40 (87%) WARN** by design — within the 40 hardware cap, fits Track 1 (satisfies #144 AC7''s "fits" clause). The patrol feature deliberately runs OAM near capacity; `MAX_PATROLS > 1` is out of scope pending a fresh audit.

Part of #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)