### PR TITLE
docs: state machine rules, race position gotcha, skill lessons

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -108,7 +108,15 @@
       "PowerShell(py *)",
       "PowerShell(Get-Process *)",
       "PowerShell(Start-Process java -ArgumentList '-jar','C:\\\\Tools\\\\Emulicious\\\\Emulicious.jar','build/nuke-raider.gb'; \"Launched PR4 ROM: $\\(\\(Get-Location\\).Path\\)\\\\build\\\\nuke-raider.gb\")",
-      "PowerShell(& \"C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe\" -c \"grep -E 'track_start_x|track_start_y|start_dir|finish' src/track_map.c | head -8; echo '=== player spawn use ==='; grep -n 'track_get_start_x\\\\|track_get_start_y\\\\|player_set_pos\\\\|spawn' src/state_playing.c src/player.c | head -8; echo '=== camera dir ==='; grep -n 'cam_y' src/camera.c | head -10\")"
+      "PowerShell(& \"C:\\\\Program Files\\\\Git\\\\bin\\\\bash.exe\" -c \"grep -E 'track_start_x|track_start_y|start_dir|finish' src/track_map.c | head -8; echo '=== player spawn use ==='; grep -n 'track_get_start_x\\\\|track_get_start_y\\\\|player_set_pos\\\\|spawn' src/state_playing.c src/player.c | head -8; echo '=== camera dir ==='; grep -n 'cam_y' src/camera.c | head -10\")",
+      "PowerShell(gh issue list --state open --limit 20 --json number,title,labels,updatedAt | ConvertFrom-Json | Sort-Object updatedAt -Descending | ForEach-Object { \"#{0}: {1} [{2}]\" -f $_.number, $_.title, \\($_.labels.name -join ', '\\) })",
+      "PowerShell(gh issue view 267 --json title,body,state,labels | ConvertFrom-Json | Select-Object title, state, @{n='body';e={$_.body.Substring\\(0,[Math]::Min\\(800,$_.body.Length\\)\\)}})",
+      "PowerShell(gh issue view 267 --json title,body | ConvertFrom-Json | ForEach-Object { $_.body })",
+      "PowerShell(gh issue view 151 --json title,body | ConvertFrom-Json | ForEach-Object { $_.body })",
+      "PowerShell(gh issue view 375 --json title,body | ConvertFrom-Json | ForEach-Object { \"=== #375 ===\"; $_.title; \"\"; $_.body })",
+      "PowerShell(gh issue view 377 --json title,body | ConvertFrom-Json | ForEach-Object { \"=== #377 ===\"; $_.title; \"\"; $_.body })",
+      "PowerShell(gh issue view 384 --json title,body | ConvertFrom-Json | ForEach-Object { \"=== #384 ===\"; $_.title; \"\"; $_.body })",
+      "PowerShell($GIT_DIR = \\(git rev-parse --git-dir 2>$null\\); $GIT_COMMON = \\(git rev-parse --git-common-dir 2>$null\\); $BRANCH = \\(git branch --show-current\\); \"GIT_DIR=$GIT_DIR\"; \"GIT_COMMON=$GIT_COMMON\"; \"BRANCH=$BRANCH\")"
     ]
   },
   "hooks": {

--- a/.claude/skills/executing-plans/SKILL.md
+++ b/.claude/skills/executing-plans/SKILL.md
@@ -67,6 +67,7 @@ For each task (whether parallel or sequential):
    - **Music C task** (creates or modifies `src/music_data.c`, `src/music_data.h`, or any new song `.c` file): dispatch `music-expert` agent (Agent tool) with prompt `"implement this task: <full task text from plan>"`. `music-expert` owns the full music pipeline (export, BANKREF declarations, `music_song_validate.py`, `music_wire_check.py`, bank-pre-write gate, build, bank-post-build gate, commit) for this task.
    - **C task** (creates or modifies other `src/*.c` or `src/*.h` files): dispatch `gbdk-expert` agent (Agent tool) with prompt `"implement this task: <full task text from plan>"`. `gbdk-expert` owns the full TDD cycle, bank gates, build, `gb-c-optimizer` review AND fix (fixes applied in-place before commit), and commit for this task.
    - **Non-C task** (docs, Python, JSON, assets): follow each step exactly as written in the plan.
+   - **`gbdk-expert` consultation gate** (plan step says "HARD GATE — gbdk-expert: Confirm X" or similar): do NOT mark this step complete until the agent has actually run and returned findings. Reading the plan's description of the consultation is NOT sufficient — the agent must execute. (Lesson from PR #362: the Y-comparison consultation was skipped and a broken approach reached a commit.)
 2a. **Post-dispatch commit verification (all implementer agents):** After the agent returns, run:
    ```bash
    git log --oneline -1

--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -122,3 +122,39 @@ cannot see the result.
 - **wait_memory timeout**: screenshot of current state is saved; check the state machine values with `grep "_state" build/nuke-raider.map`
 - **PyBoy crash mid-navigation**: best-effort screenshot saved; exit non-zero
 - **Symbol not found**: run `grep "_your_symbol" build/nuke-raider.map` to find the exact name SDCC emitted
+
+## Headless WRAM Read (State Inspection)
+
+Use when the symptom is a wrong WRAM value, not a visual glitch — faster than launching Emulicious.
+
+### Pattern
+
+**1. Export debug globals in `src/foo.c` alongside the static variables:**
+```c
+uint8_t dbg_foo_armed;
+int8_t  dbg_foo_pvy;
+uint8_t dbg_foo_cps;
+```
+
+**2. Find their addresses after building:**
+```bash
+grep "dbg_foo" build/nuke-raider.map
+```
+Addresses shift if WRAM layout changes — always re-grep after a new build.
+
+**3. Read them via PyBoy:**
+```python
+from pyboy import PyBoy
+pyboy = PyBoy('build/nuke-raider.gb', window='null')   # no cgb_mode kwarg — causes KeyError
+pyboy.set_emulation_speed(0)
+# ... navigate with pyboy.send_input() + pyboy.advance_frame() ...
+val = pyboy.memory[0xC373]   # address from .map grep
+```
+
+**CRITICAL:** `window='null'` is the correct headless flag. Do NOT pass `cgb_mode=True` — it raises `KeyError: Unknown keyword argument`.
+
+### Combined workflow
+
+1. Use `screenshot.py` with `wait_memory` steps to navigate to the exact game state
+2. Then read multiple adjacent WRAM bytes directly from `pyboy.memory[addr]`
+3. Compare values against expected to confirm/rule out hypotheses without opening Emulicious

--- a/.claude/skills/systematic-debugging/SKILL.md
+++ b/.claude/skills/systematic-debugging/SKILL.md
@@ -179,6 +179,8 @@ When triggered:
 - **`emulicious-debug`** agent — step-through debugger, EMU_printf, memory/tile/sprite inspection, tracer, profiler
 - **`/compare-prs <N>`** skill — for "worked in PR X, broken now" hypotheses: builds both, lets you compare ROMs and diffs side-by-side
 - **`build/game-manifest.json`** — read before writing any `wait_memory` address or navigation steps; `symbols` section provides WRAM addresses for all key state variables, `navigation` section provides overmap paths — no source reads required
+- **DEBUG=1 build** — `DEBUG=1 GBDK_HOME=/home/mathdaman/gbdk make` enables `EMU_printf` output in Emulicious. Use `DBG_INT(label, val)` from `src/debug.h` — one value per call. `EMU_printf` with 4+ format args causes `error 101: too many parameters` under SDCC — split into multiple `DBG_INT` calls or separate `EMU_printf(fmt, single_arg)` calls.
+- **Headless WRAM read** — export `uint8_t`/`int8_t` debug globals, find their addresses via `grep` on `build/nuke-raider.map`, then read `pyboy.memory[addr]` after scripted navigation. See the `screenshot` skill for the full pattern and the `window='null'` / no-`cgb_mode` caveats.
 
 ---
 
@@ -193,3 +195,5 @@ When triggered:
 **Static WRAM symbol lookup:** SDCC does not export `static` file-scope variable names to the `.map` symbol table — `find_wram_sym_from_map` only works for non-static globals. For `static` WRAM variables, use `find_wram_read_in_fn(noi_path, rom_path, "_getter_fn")` from `tests/integration/helpers.py`. It decodes the getter function's disassembly from the ROM binary to locate the `LD A,(nn)` opcode and extract the WRAM address. Formula: `bank = noi_addr >> 16; phys = gb_addr if bank == 0 else (bank-1)*0x4000 + gb_addr`.
 
 **"Grey screen, game logic running, text invisible" → check scroll registers first:** The VBL ISR in `main.c` calls `move_bkg(cam_scx_shadow, cam_scy_shadow)` every frame unconditionally. Any state entered after `state_playing` inherits the race's final scroll offset unless `sp_exit()` resets `cam_scx_shadow = 0u; cam_scy_shadow = 0u`. Before assuming a VRAM or palette bug, read `SCY`/`SCX` in Emulicious — non-zero values mean the tilemap is rendering off-screen.
+
+**`finish_eval()` direction-velocity race:** Any `BANKED` physics blocker (e.g. `racer_blocks_pixel()`) can zero `vy` on the same frame the player reaches a finish/checkpoint tile. If `finish_eval()` gates on `pvy > 0`, that check silently fails even though the player crossed correctly. Prefer `player_get_dir()` facing-direction over instantaneous velocity. Confirm headlessly: export `dbg_pvy` and read it via PyBoy at the crossing frame — if `pvy=0` despite correct facing direction, this is the cause (tracked in issue #382).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,22 @@ States: `STATE_INIT` → `STATE_TITLE` → `STATE_OVERMAP` → `STATE_PLAYING` �
 
 Each game system lives in `src/<system>.c` + `src/<system>.h`. Asset source files (sprites, tiles, music) live under `assets/` and must be converted to C data arrays before use. Converted headers go in `src/`. All `.c` files in `src/` are automatically compiled by the Makefile.
 
+## State Machine Rules
+
+Three legal transitions (defined in `src/state_manager.c`, `STACK_MAX = 2`):
+
+| Call | Effect | Use when |
+|------|--------|----------|
+| `state_push(next, args)` | depth +1 | Entering a sub-state (e.g. overmap → prerace) |
+| `state_pop()` | depth -1 | Returning to the previous state (e.g. game_over → overmap) |
+| `state_replace(next, args)` | depth unchanged | Lateral swap at the same level (e.g. prerace → playing) |
+
+**WARNING: `state_replace` never reduces stack depth.** Using it to "go back" is a silent bug — the stack leaks one slot per navigation cycle. With `STACK_MAX = 2`, a leaked slot means the next `state_push` silently no-ops (push skipped, no error, no crash).
+
+Canonical race path: `title(0) → overmap(0) → prerace(+1=1) → playing(1) → game_over(1) → state_pop() → overmap(0)`
+
+`state_results` already uses `state_pop()` — follow this pattern for any "race ended" transition.
+
 ## Game Design & Influences
 
 Full design doc: [`docs/game/game-design.md`](docs/game/game-design.md) — consult before making feature, tone, or UX decisions.
@@ -147,6 +163,19 @@ These live in `.claude/skills/` and take precedence over the global superpowers 
 - **One variable per test**: Never make two changes between test runs. Instrument, build, observe, conclude — one hypothesis at a time.
 - **Worktree CWD**: Before every `make` or emulator launch, verify the current directory is the correct worktree directory (`pwd`). After any worktree cleanup, `cd` to a valid directory before running further commands.
 - **PR navigation**: When the user says "go back again", "next one", or any relative reference during sequential PR testing, state the exact PR number out loud and confirm before doing the checkout.
+
+## Game Logic Sharp Edges
+
+**Race position — raw Y coordinate is not a valid "who is ahead" metric on winding tracks:**
+Track2 is an oval: down the right side (ty increases), up the left side (ty decreases). Two competitors at the same Y value can be at completely different positions on the track — the comparison flips randomly. Use section-aware comparison:
+- Detect side: `player_tx > 10` = right side; `racer_wp_idx < 6` = right side
+- Right side (going down): higher `ty` = further ahead
+- Left side (going up): lower `ty` = further ahead
+- Different sides: the competitor on the left side is further along
+- General rule: use waypoint progress scores (`laps × wp_count + wp_idx`), not raw pixel coordinates.
+
+**Player waypoint tracking uses different thresholds than the racer:**
+The racer steers toward waypoints; the player drives freely. `RACER_WP_THRESHOLD * 2 = 24px` is too tight for player WP detection on track2 (player start at (96,40), WP0 at (124,44) — 32px east, never within 24px). Use ≥32px threshold or initialize to nearest waypoint at race start.
 
 ## PRD vs Implementation Plan
 


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: New `State Machine Rules` section — push/pop/replace semantics, `STACK_MAX=2` silent-fail warning, canonical race path
- **CLAUDE.md**: New `Game Logic Sharp Edges` section — raw-Y race position is broken on winding tracks; player WP threshold differs from racer
- **executing-plans skill**: `gbdk-expert` consultation gate must actually execute — not just be read from the plan (lesson from PR #362 Y-comparison skip)
- **screenshot skill**: Headless WRAM read pattern via PyBoy (`window='null'`, no `cgb_mode` kwarg)
- **systematic-debugging skill**: `DEBUG=1` build + `DBG_INT` note; `finish_eval()` direction-velocity race pattern

## Test plan
- [ ] ROM builds cleanly (512K, no errors)
- [ ] Doc changes are factually accurate vs. the issues they close

Closes #375
Closes #377
Closes #384

Generated with Claude Code