### PR TITLE
feat: scene-aware OAM accounting + auto-synced memory explainer

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -127,7 +127,13 @@
       "PowerShell(Test-Path \"C:\\\\Users\\\\mathd\\\\.claude\\\\skills\\\\optimize-context\\\\references\\\\\" -PathType Container; if \\(-not \\(Test-Path \"C:\\\\Users\\\\mathd\\\\.claude\\\\skills\\\\optimize-context\\\\references\\\\\" -PathType Container\\)\\) { New-Item -ItemType Directory -Path \"C:\\\\Users\\\\mathd\\\\.claude\\\\skills\\\\optimize-context\\\\references\\\\\" -Force | Out-Null }; Test-Path \"C:\\\\Users\\\\mathd\\\\.claude\\\\skills\\\\optimize-context\\\\references\\\\\")",
       "PowerShell(python -c \"import yaml; f=open\\(r'C:\\\\Users\\\\mathd\\\\.claude\\\\skills\\\\optimize-context\\\\SKILL.md',encoding='utf-8'\\).read\\(\\); fm=f.split\\('---'\\)[1]; d=yaml.safe_load\\(fm\\); assert d['name']=='optimize-context'; assert d['disable-model-invocation'] is True; print\\('frontmatter OK:', list\\(d.keys\\(\\)\\)\\)\")",
       "PowerShell(foreach \\($n in 409,267,214,205,151,148,147,139,258\\) { Write-Output \"===== #$n =====\"; gh issue view $n --json title,body --jq '.title, \\(.body | .[0:500]\\)'; Write-Output \"\" })",
-      "PowerShell(git log *)"
+      "PowerShell(git log *)",
+      "PowerShell(python tools/memory_check.py . 2>&1; Write-Output \"---BANKPOST---\"; python tools/bank_post_build.py . 2>&1 | Select-Object -First 60)",
+      "PowerShell(make *)",
+      "PowerShell($noi = Get-Content build/nuke-raider.noi; $banks = @{}; foreach \\($line in $noi\\) { if \\($line -match '^DEF\\\\s+\\\\S'\\) {} }; Write-Output \"=== Sample of .noi \\(DEF lines with addresses\\) ===\"; $noi | Select-String '^DEF' | Select-Object -First 5; Write-Output \"=== Searching map for Area/bank summary ===\"; Select-String -Path build/nuke-raider.map -Pattern '_CODE_|ROM bank|_HOME|HEADER' | Select-Object -First 30 | ForEach-Object { $_.Line })",
+      "PowerShell(Start-Process \"docs/memory-explained.html\")",
+      "PowerShell(Copy-Item *)",
+      "PowerShell(python -m pytest tests/test_memory_check.py -q 2>&1 | Select-Object -Last 15)"
     ]
   },
   "hooks": {

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ TEST_FLAGS   := -Itests/mocks -Itests/unity/src -Isrc -Ilib/hUGEDriver/include -
 TEST_LIB_SRC := $(filter-out src/main.c,$(wildcard src/*.c))
 MOCK_SRCS    := $(wildcard tests/mocks/*.c)
 
-.PHONY: all clean test test-tools export-sprites bank-check bank-post-build memory-check tile-check dialog_data build-debug
+.PHONY: all clean test test-tools export-sprites bank-check bank-post-build memory-check tile-check dialog_data build-debug sync-docs
 
-all: $(TARGET)
+all: $(TARGET) sync-docs
 
 # ── Generated sources ─────────────────────────────────────────────────────────
 # ── Tile rotation pipeline ──────────────────────────────────────────────────
@@ -221,7 +221,7 @@ src/overmap_car_sprite.c: assets/sprites/overmap_car.png tools/png_to_tiles.py
 $(TARGET): src/overmap_car_sprite.c
 
 test-tools:
-	PYTHONPATH=. python -m unittest tests.test_png_to_tiles tests.test_tmx_to_c tests.test_bank_check tests.test_bank_post_build tests.test_dialog_to_c tests.test_balancer tests.test_emit_manifest -v
+	PYTHONPATH=. python -m unittest tests.test_png_to_tiles tests.test_tmx_to_c tests.test_bank_check tests.test_bank_post_build tests.test_dialog_to_c tests.test_balancer tests.test_emit_manifest tests.test_memory_check tests.test_sync_scene_data -v
 
 # Validate #pragma bank in src/*.c against bank-manifest.json — fails build on mismatch
 bank-check:
@@ -232,6 +232,11 @@ bank-post-build:
 
 memory-check:
 	python tools/memory_check.py .
+
+# Keep docs/memory-explained.html's OAM scene model in sync with src/config.h.
+# Idempotent: only changes bytes when config.h actually changes (no build churn).
+sync-docs:
+	python tools/sync_scene_data.py .
 
 tile-check: $(TARGET)
 	python tools/check_tile_budget.py .

--- a/README.md
+++ b/README.md
@@ -139,3 +139,4 @@ gmb-nuke-raider/
 - [Asset pipeline](docs/asset-pipeline.md) — full asset authoring and conversion workflow
 - [Tile system reference](docs/TILES.md) — hardware limits, per-state tile budgets, and pipeline workflow
 - [Developer workflow](docs/dev-workflow.md) — build gates, debugging, and contribution conventions
+- [Memory explained](docs/memory-explained.html) — interactive ROM-memory tour (banks, VRAM, per-scene OAM); its OAM scene model auto-syncs with `config.h` on every `make`

--- a/docs/memory-explained.html
+++ b/docs/memory-explained.html
@@ -1,0 +1,498 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nuke Raider — How the ROM's Memory Works (Click Everything)</title>
+<style>
+  :root{
+    --bg:#0e1117; --panel:#161b22; --panel2:#1c2330; --ink:#e6edf3; --dim:#8b949e;
+    --line:#30363d; --accent:#f0883e; --green:#3fb950; --amber:#d29922; --red:#f85149;
+    --blue:#58a6ff; --purple:#bc8cff; --teal:#39c5cf;
+    --mono:'Consolas','SF Mono',Menlo,monospace;
+    --sans:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--bg);color:var(--ink);font-family:var(--sans);line-height:1.6}
+  header{padding:32px 24px 16px;border-bottom:1px solid var(--line);background:linear-gradient(180deg,#1a2230,#0e1117)}
+  header h1{margin:0 0 4px;font-size:28px;letter-spacing:.5px}
+  header h1 span{color:var(--accent)}
+  header p{margin:0;color:var(--dim);max-width:720px}
+  .wrap{max-width:1100px;margin:0 auto;padding:24px}
+  .lede{background:var(--panel);border:1px solid var(--line);border-left:4px solid var(--accent);
+    border-radius:8px;padding:16px 20px;margin:24px 0}
+  .lede b{color:var(--accent)}
+  h2{margin:40px 0 6px;font-size:21px;border-bottom:1px solid var(--line);padding-bottom:8px}
+  h2 .num{color:var(--accent);font-family:var(--mono);margin-right:8px}
+  .sub{color:var(--dim);margin:0 0 18px;font-size:14px}
+  .hint{font-size:12px;color:var(--teal);font-style:italic}
+
+  /* budgets */
+  .budgets{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px;margin:20px 0}
+  .bcard{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:16px;cursor:pointer;transition:.15s}
+  .bcard:hover{border-color:var(--accent);transform:translateY(-2px)}
+  .bcard .label{font-size:13px;color:var(--dim);text-transform:uppercase;letter-spacing:1px}
+  .bcard .val{font-size:26px;font-weight:700;font-family:var(--mono);margin:4px 0}
+  .bar{height:10px;border-radius:6px;background:#222b38;overflow:hidden;margin-top:8px}
+  .bar > i{display:block;height:100%;border-radius:6px}
+  .tag{display:inline-block;font-size:11px;font-weight:700;padding:2px 8px;border-radius:20px;margin-top:8px}
+  .tag.pass{background:rgba(63,185,80,.15);color:var(--green)}
+  .tag.warn{background:rgba(210,153,34,.18);color:var(--amber)}
+
+  /* clickable regions */
+  .region,.bankcell,.tilecell,.oamcell{cursor:pointer;transition:.12s}
+  .region:hover,.bankcell:hover,.tilecell:hover,.oamcell:hover{filter:brightness(1.25);outline:2px solid var(--ink)}
+  .active-el{outline:3px solid var(--accent)!important;box-shadow:0 0 14px rgba(240,136,62,.5)}
+
+  /* memory map */
+  .memmap{display:flex;flex-direction:column;gap:3px;font-family:var(--mono);font-size:13px;max-width:560px}
+  .region{display:flex;justify-content:space-between;align-items:center;padding:11px 14px;border-radius:6px;color:#0e1117;font-weight:600}
+  .region .addr{font-size:11px;opacity:.8}
+  .r-rom0{background:#7ee787}
+  .r-romx{background:#f0883e}
+  .r-vram{background:#79c0ff}
+  .r-sram{background:#a371f7}
+  .r-wram{background:#56d4dd}
+  .r-echo{background:#484f58;color:#c9d1d9}
+  .r-oam{background:#ff7b72}
+  .r-io{background:#d2a8ff}
+  .r-hram{background:#ffa657}
+
+  /* banks grid */
+  .bankgrid{display:grid;grid-template-columns:repeat(8,1fr);gap:5px;max-width:640px}
+  .bankcell{aspect-ratio:1;display:flex;flex-direction:column;align-items:center;justify-content:center;
+    border-radius:5px;font-family:var(--mono);font-size:11px;font-weight:700;color:#0e1117;text-align:center;padding:2px}
+  .bk-home{background:#7ee787}
+  .bk-auto{background:#388bfd}
+  .bk-music{background:#bc8cff}
+  .bankcell small{font-size:8px;font-weight:400;opacity:.85;line-height:1.1}
+
+  /* tile strip */
+  .tilestrip{display:flex;height:46px;border-radius:6px;overflow:hidden;max-width:640px;font-family:var(--mono);font-size:11px;font-weight:700}
+  .tilecell{display:flex;align-items:center;justify-content:center;color:#0e1117;text-align:center;padding:0 6px}
+  .t-font{background:#8b949e}
+  .t-hud{background:#f0883e}
+  .t-pool{background:#56d4dd}
+  .t-free{background:#30363d;color:#8b949e}
+
+  /* oam grid */
+  .oamgrid{display:grid;grid-template-columns:repeat(10,1fr);gap:4px;max-width:520px}
+  .oamcell{aspect-ratio:1;border-radius:4px;display:flex;align-items:center;justify-content:center;
+    font-family:var(--mono);font-size:10px;font-weight:700;color:#0e1117}
+  .o-free{background:#30363d;color:#6e7681}
+
+  /* scene selector */
+  .scenebtns{display:flex;flex-wrap:wrap;gap:8px;margin:14px 0}
+  .scenebtn{cursor:pointer;border:1px solid var(--line);background:var(--panel);color:var(--ink);
+    font-family:var(--sans);font-size:13px;font-weight:600;padding:7px 14px;border-radius:20px;transition:.12s}
+  .scenebtn:hover{border-color:var(--accent)}
+  .scenebtn.sel{background:var(--accent);color:#0e1117;border-color:var(--accent)}
+  .scenebtn small{display:block;font-size:10px;font-weight:400;opacity:.8}
+  .scene-readout{font-family:var(--mono);font-size:13px;margin:6px 0 2px;padding:10px 14px;
+    background:var(--panel);border:1px solid var(--line);border-radius:8px}
+  .scene-readout b{color:var(--accent)}
+  .scene-readout .st-pass{color:var(--green)} .scene-readout .st-warn{color:var(--amber)} .scene-readout .st-fail{color:var(--red)}
+  .mythbuster{background:rgba(88,166,255,.08);border-left:3px solid var(--blue);border-radius:4px;
+    padding:10px 14px;margin:8px 0 4px;font-size:13px}
+  .mythbuster b{color:var(--blue)}
+
+  /* legend */
+  .legend{display:flex;flex-wrap:wrap;gap:14px;margin:12px 0;font-size:12px;color:var(--dim)}
+  .legend span{display:flex;align-items:center;gap:6px}
+  .legend i{width:14px;height:14px;border-radius:3px;display:inline-block}
+
+  /* detail panel */
+  #detail{position:sticky;bottom:0;margin-top:20px;background:var(--panel2);border:1px solid var(--accent);
+    border-radius:10px;padding:18px 20px;min-height:96px;box-shadow:0 -4px 24px rgba(0,0,0,.4)}
+  #detail h3{margin:0 0 8px;font-size:17px;color:var(--accent)}
+  #detail p{margin:6px 0;font-size:14px}
+  #detail .meta{font-family:var(--mono);font-size:12px;color:var(--teal);margin-bottom:8px}
+  #detail .analogy{background:rgba(88,166,255,.08);border-left:3px solid var(--blue);padding:8px 12px;
+    border-radius:4px;margin-top:10px;font-size:13px}
+  #detail .analogy b{color:var(--blue)}
+  #detail .placeholder{color:var(--dim);font-style:italic}
+
+  table{border-collapse:collapse;width:100%;font-size:13px;margin:10px 0}
+  th,td{text-align:left;padding:7px 10px;border-bottom:1px solid var(--line)}
+  th{color:var(--dim);font-weight:600;text-transform:uppercase;font-size:11px;letter-spacing:.5px}
+  td.mono{font-family:var(--mono);color:var(--teal)}
+  footer{color:var(--dim);font-size:12px;text-align:center;padding:30px;border-top:1px solid var(--line);margin-top:40px}
+  code{background:#22272e;padding:1px 6px;border-radius:4px;font-family:var(--mono);font-size:12px;color:var(--accent)}
+</style>
+</head>
+<body>
+<header>
+  <h1>🎮 <span>Nuke Raider</span> — How the ROM's Memory Works</h1>
+  <p>An explain-it-like-I'm-five tour of Game Boy memory: cartridge banks, VRAM, OAM and WRAM.
+     <b style="color:var(--accent)">Click any colored box</b> — the panel at the bottom tells you what it is.</p>
+</header>
+
+<div class="wrap">
+
+  <div class="lede">
+    <b>The 30-second version.</b> A Game Boy is a tiny computer with almost no memory. The big game lives
+    on the cartridge as <b>ROM</b> (read-only, can't change). But the CPU can only "see" a small window of it
+    at a time, so the cartridge swaps chunks in and out — those chunks are called <b>banks</b>.
+    The console's own scratch memory is split into special-purpose rooms: <b>VRAM</b> (the picture book of
+    tiles & colors), <b>OAM</b> (the list of moving sprites), and <b>WRAM</b> (variables & game state).
+    Everything below is real, measured from <em>this</em> build of the ROM.
+  </div>
+
+  <!-- ===================== LIVE BUDGETS ===================== -->
+  <h2><span class="num">①</span>The scoreboard <span class="hint">(real numbers from this build)</span></h2>
+  <p class="sub">How full is each memory area right now? Click a card for what it means and where the number comes from.</p>
+  <div class="budgets" id="budgets">
+    <div class="bcard" data-key="rom">
+      <div class="label">ROM (cartridge)</div>
+      <div class="val">512 <small style="font-size:14px">KB</small></div>
+      <div class="bar"><i style="width:100%;background:var(--accent)"></i></div>
+      <span class="tag pass">32 / 32 banks declared</span>
+    </div>
+    <div class="bcard" data-key="wram">
+      <div class="label">WRAM (work RAM)</div>
+      <div class="val">1,205 <small style="font-size:14px">/ 8,192 B</small></div>
+      <div class="bar"><i style="width:14%;background:var(--green)"></i></div>
+      <span class="tag pass">14% · PASS</span>
+    </div>
+    <div class="bcard" data-key="vram">
+      <div class="label">VRAM (tiles)</div>
+      <div class="val">74 <small style="font-size:14px">/ 384 tiles</small></div>
+      <div class="bar"><i style="width:19%;background:var(--green)"></i></div>
+      <span class="tag pass">19% · PASS</span>
+    </div>
+    <div class="bcard" data-key="oam">
+      <div class="label">OAM (busiest scene)</div>
+      <div class="val">32 <small style="font-size:14px">/ 40 slots</small></div>
+      <div class="bar"><i style="width:80%;background:var(--amber)"></i></div>
+      <span class="tag warn">80% · ⚠ WARN</span>
+    </div>
+  </div>
+
+  <!-- ===================== MEMORY MAP ===================== -->
+  <h2><span class="num">②</span>The whole memory map <span class="hint">(what the CPU sees)</span></h2>
+  <p class="sub">The CPU has 65,536 addresses (0x0000–0xFFFF). Each stripe below is a "room" with a fixed job.
+     Click a stripe to learn what lives there.</p>
+  <div class="memmap" id="memmap">
+    <div class="region r-rom0" data-key="rom0"><span>ROM Bank 0 — always loaded (HOME)</span><span class="addr">0000–3FFF</span></div>
+    <div class="region r-romx" data-key="romx"><span>ROM Bank 1–31 — swappable window</span><span class="addr">4000–7FFF</span></div>
+    <div class="region r-vram" data-key="vram"><span>VRAM — tiles &amp; maps (the picture book)</span><span class="addr">8000–9FFF</span></div>
+    <div class="region r-sram" data-key="sram"><span>Cartridge RAM — save data (unused here)</span><span class="addr">A000–BFFF</span></div>
+    <div class="region r-wram" data-key="wram"><span>WRAM — variables &amp; game state</span><span class="addr">C000–DFFF</span></div>
+    <div class="region r-echo" data-key="echo"><span>Echo RAM — mirror, don't touch</span><span class="addr">E000–FDFF</span></div>
+    <div class="region r-oam" data-key="oam"><span>OAM — the 40-sprite list</span><span class="addr">FE00–FE9F</span></div>
+    <div class="region r-io" data-key="io"><span>I/O Registers — knobs &amp; dials</span><span class="addr">FF00–FF7F</span></div>
+    <div class="region r-hram" data-key="hram"><span>HRAM — tiny ultra-fast scratchpad</span><span class="addr">FF80–FFFE</span></div>
+  </div>
+
+  <!-- ===================== BANKS ===================== -->
+  <h2><span class="num">③</span>The cartridge banks <span class="hint">(why we don't run out of room)</span></h2>
+  <p class="sub">The swappable window (orange stripe above) is only 16&nbsp;KB. But the cart holds 512&nbsp;KB.
+     So the game is sliced into <b>32 banks</b> of 16&nbsp;KB each, and the cart swaps one into the window when needed.
+     <b>Bank 0 is special</b> — it's <em>always</em> visible, so the most important code lives there.
+     Click any bank.</p>
+  <div class="legend">
+    <span><i class="bk-home"></i> Bank 0 — HOME (always mapped)</span>
+    <span><i class="bk-auto"></i> Auto-banked (compiler assigns)</span>
+    <span><i class="bk-music"></i> Bank 31 — music data (pinned)</span>
+  </div>
+  <div class="bankgrid" id="bankgrid"></div>
+
+  <!-- ===================== VRAM ===================== -->
+  <h2><span class="num">④</span>VRAM — the picture book <span class="hint">(tiles)</span></h2>
+  <p class="sub">The Game Boy can't draw free-form pixels. It draws <b>8×8 tiles</b> — like LEGO bricks.
+     VRAM stores up to <b>384 tile pictures</b> (192 per color bank × 2 on the GBC).
+     Backgrounds and the HUD all share one strip. Click a section.</p>
+  <div class="tilestrip" id="tilestrip">
+    <div class="tilecell t-font" data-key="t-font" style="flex:128">0–127<br>font</div>
+    <div class="tilecell t-hud" data-key="t-hud" style="flex:15">128–142<br>HUD</div>
+    <div class="tilecell t-pool" data-key="t-pool" style="flex:112">143–254<br>game pool</div>
+    <div class="tilecell t-free" data-key="t-free" style="flex:129">255+ free</div>
+  </div>
+  <p class="hint" style="margin-top:8px">Widths are roughly to scale across the 384-tile budget. "Sprites" use the same tile memory as backgrounds.</p>
+
+  <!-- ===================== OAM ===================== -->
+  <h2><span class="num">⑤</span>OAM — the moving things <span class="hint">(per scene!)</span></h2>
+  <p class="sub">A <b>sprite</b> is a tile that moves freely (your car, bullets, enemies). The hardware allows
+     exactly <b>40</b> sprite slots — no more, ever. But here's the trick: <b>every scene reuses the same pool.</b>
+     When the game changes scene it wipes the sprite list and refills it, so only <em>one</em> scene's sprites
+     are ever on screen. The budget that matters is the <b>busiest single scene</b> — not the whole game added up.</p>
+  <div class="mythbuster">
+    <b>Myth-buster:</b> the old "35/40" was a build-time worst-case <em>sum</em>. Real OAM is per-scene,
+    and the only scene that gets close to the wall is <b>Playing</b> (32/40). Pick a scene below and watch
+    the 40 slots fill differently.
+  </div>
+  <div class="scenebtns" id="scenebtns"></div>
+  <div class="scene-readout" id="sceneReadout"></div>
+  <div class="legend" id="oamLegend"></div>
+  <div class="oamgrid" id="oamgrid"></div>
+
+  <!-- ===================== DETAIL PANEL ===================== -->
+  <div id="detail">
+    <p class="placeholder">👆 Click anything above — colored stripes, banks, tiles, sprite slots, or the scoreboard cards — and the explanation appears here.</p>
+  </div>
+
+</div>
+
+<footer>
+  Generated for Nuke Raider · figures measured from <code>build/nuke-raider.gb</code> (512&nbsp;KB, MBC5, CGB-compatible).<br>
+  Sources: <code>bank-manifest.json</code>, <code>src/config.h</code>, <code>tools/memory_check.py</code>.
+</footer>
+
+<script>
+/* ---------- detail content ---------- */
+const D = {
+  /* budgets */
+  rom:{t:"ROM — the cartridge chip",m:"512 KB · 32 banks · MBC5 mapper · -Wm-yt25 -Wm-yc",
+    h:"This is the game itself: all code, art, maps and music, burned in and read-only. It can never change while playing. Bigger games need more banks; we declared 32 (the max for this layout) and currently use all 512 KB of address space.",
+    a:"Like a printed book — every page is already there, you just can't write new pages while reading."},
+  wram:{t:"WRAM — work RAM",m:"1,205 / 8,192 bytes used (14%) · status PASS",
+    h:"The console's scratchpad for things that change every frame: your position, speed, HP, enemy arrays, the score. Measured from the s__HEAP_E symbol in the build map. We're using only 14% — lots of headroom.",
+    a:"Like a whiteboard you erase and rewrite constantly during play."},
+  vram:{t:"VRAM budget — tile pictures",m:"74 / 384 tiles used (19%) · status PASS",
+    h:"How many unique 8×8 tile images are loaded. Counted from every *_count value in src/*_tiles.c. 384 = 192 tiles × 2 GBC color banks. Plenty of room left.",
+    a:"Like a box of 384 unique LEGO bricks — you're only using 74 designs so far."},
+  oam:{t:"OAM budget — busiest scene",m:"32 / 40 slots (80%) · status ⚠ WARN · scene: Playing",
+    h:"The hardware hard-limits you to 40 moving sprites, period. Scenes are mutually exclusive and share one recycling pool, so the number that matters is the busiest single scene — Playing, at 32/40. The build's memory_check.py also cross-checks that the pool size (MAX_SPRITES=32) exactly matches this peak. This is the budget to watch.",
+    a:"Like a 40-seat theater that hosts one show at a time. The biggest show (Playing) seats 32; the others use far fewer. You only ever need the biggest show to fit."},
+
+  /* memory map */
+  rom0:{t:"ROM Bank 0 — HOME (0x0000–0x3FFF)",m:"Always visible · never swapped out",
+    h:"The 16 KB that's ALWAYS loaded. Anything that must work no matter which bank is swapped in lives here: the game entry/loop (main.c), the bank-switching dispatcher (state_manager.c), the VRAM loaders (loader.c), and audio (music.c, sfx.c) — because audio runs during interrupts and must never vanish mid-swap.",
+    a:"The lobby of a hotel — every floor changes, but the lobby is always there."},
+  romx:{t:"ROM Bank 1–31 — the swap window (0x4000–0x7FFF)",m:"16 KB window · one bank visible at a time",
+    h:"A 16 KB 'porthole' onto the rest of the cartridge. The MBC5 chip slides whichever bank you ask for into this window. Only bank-0 code is allowed to trigger a swap (via SWITCH_ROM), so a swap can't pull the rug out from under the code doing the swapping.",
+    a:"A single window with 31 interchangeable backdrops — you slide the one you need into view."},
+  sram:{t:"Cartridge RAM (0xA000–0xBFFF)",m:"Unused in Nuke Raider",
+    h:"Battery-backed save memory on the cart. Nuke Raider doesn't save progress, so this room sits empty.",
+    a:"A safe-deposit box we never rented."},
+  echo:{t:"Echo RAM (0xE000–0xFDFF)",m:"Hardware mirror of WRAM — do not use",
+    h:"The hardware mirrors WRAM here as a quirk. Nintendo says don't touch it. We don't.",
+    a:"A funhouse mirror of the whiteboard — looks real, but writing on it is asking for trouble."},
+  io:{t:"I/O Registers (0xFF00–0xFF7F)",m:"Hardware control knobs",
+    h:"Memory-mapped dials: which buttons are pressed, scroll position (SCX/SCY), sound channels, the LCD controller, interrupt flags. You change the hardware by writing to these addresses.",
+    a:"The control panel — flip a switch by writing a number to its address."},
+  hram:{t:"HRAM (0xFF80–0xFFFE)",m:"127 bytes · fastest memory",
+    h:"A tiny sliver of ultra-fast RAM the CPU can reach even during certain operations when other memory is locked. Used for the most timing-critical scratch values (and the DMA sprite-copy routine).",
+    a:"The sticky note on your hand — tiniest space, but instantly reachable."},
+
+  /* banks */
+  "bank-home":{t:"Bank 0 — HOME",m:"Always mapped · src/main.c, loader.c, music.c, sfx.c, state_manager.c, state_hub.c, state_overmap.c, hub_data.c",
+    h:"The always-on bank. Holds the game loop, the state dispatcher that performs every bank switch, the VRAM loaders, and the audio engine (audio runs in the VBlank interrupt and must never be swapped away). Files here have NO #pragma bank.",
+    a:"The hotel lobby — always there, holds the front desk and the elevator controls."},
+  "bank-music":{t:"Bank 31 — music data (pinned)",m:"src/music_data.c · ~11 KB · explicitly pinned",
+    h:"The song data is large (~11 KB) and is deliberately nailed to the last bank so it can never collide with growing game-data banks. Pinning = we chose its bank by hand instead of letting the compiler decide.",
+    a:"A reserved parking spot at the far end of the lot, so nobody else ever parks there."},
+  "bank-auto":{t:"Auto-banked pool (banks 1–30)",m:"~40 files · {\"bank\":255} = compiler assigns",
+    h:"Most of the game — gameplay modules (player, racer, turret, patrol, projectile, explosion…), sprite art, tilesets, track maps, and per-state screens — is marked 'autobank' (255). The linker packs them into whichever banks have room. The state dispatcher swaps the right one in before calling into it.",
+    a:"General parking — you don't pick a spot, the attendant fits each car wherever it lands."},
+
+  /* tiles */
+  "t-font":{t:"Tiles 0–127 — system font",m:"Loaded by GBDK at boot",
+    h:"The built-in ASCII font that printf() uses. It's written automatically when the game starts, occupying the first 128 tile slots.",
+    a:"The pre-printed alphabet stamps that come in the box."},
+  "t-hud":{t:"Tiles 128–142 — HUD font",m:"15 tiles · HUD_FONT_BASE in config.h",
+    h:"Custom digits and symbols (H, P, :, /, space, 0–9) for the heads-up display — HP and lap counters. Loaded by hud_init().",
+    a:"A custom rubber-stamp set just for the scoreboard."},
+  "t-pool":{t:"Tiles 143–254 — game tile pool",m:"loader-managed · LOADER_BG_START",
+    h:"The flexible pool the loader fills at runtime with whatever the current screen needs: track tiles, overmap tiles, NPC portraits, powerup icons. Reused as you move between screens.",
+    a:"A shared bin of LEGO bricks — dumped out and refilled depending on what you're building right now."},
+  "t-free":{t:"Tiles 255+ — free headroom",m:"unused budget",
+    h:"The remaining slots toward the 384-tile cap (192 per GBC color bank × 2). Room to grow.",
+    a:"Empty shelves in the brick cupboard."},
+
+  /* oam consumers (per-scene) */
+  "c-player":{t:"Player car — 4 slots",m:"4 get_sprite() calls in player_init",
+    h:"Your car is 16×16 = 4 hardware sprites. It grabs the first 4 pool slots when the race starts and keeps them for the whole race.",
+    a:"The lead actor — front row, reserved for the whole show."},
+  "c-projectiles":{t:"Projectiles — up to 8 slots",m:"MAX_PROJECTILES = 8",
+    h:"Bullets you fire. Each takes one pool slot on spawn and frees it when it expires or hits something.",
+    a:"Quick cameo actors — on stage for a second, then they free the seat."},
+  "c-turrets":{t:"Turrets / static enemies — up to 8 slots",m:"MAX_ENEMIES = 8",
+    h:"Stationary gun emplacements, one pool slot each. When a turret dies its slot becomes the explosion, then frees — no extra slot needed.",
+    a:"Sentries posted around the stage; when one falls, its seat becomes the smoke puff, then empties."},
+  "c-racers":{t:"Enemy racers — up to 8 slots",m:"MAX_ENEMY_RACERS (2) × 4 slots each",
+    h:"Rival cars, also 16×16 = 4 slots each, allocated lazily as they appear. Two enemy racers = 8 slots.",
+    a:"Two rival drivers, each needing four seats for their crew."},
+  "c-patrol":{t:"Patrol car — 4 slots",m:"MAX_PATROLS (1) × 4 slots",
+    h:"The mobile combat AI that chases you. One car, 16×16 = 4 slots.",
+    a:"A roaming heckler who takes four seats wherever it goes."},
+  "c-car":{t:"Overmap car — 1 slot",m:"slot 0 (overmap clears slots 1–39)",
+    h:"On the world map you're a single small sprite driving between hubs. Just one slot; everything else is background tiles.",
+    a:"A lone game piece sliding across the board."},
+  "c-dialog_arrow":{t:"Dialog arrow — 1 slot",m:"DIALOG_ARROW_OAM_SLOT (slot 4)",
+    h:"The 'more text' indicator in hub conversations. The only sprite in the hub — NPC portraits are background tiles, not sprites.",
+    a:"A single blinking 'continue' light on an otherwise still stage."},
+  "c-free":{t:"Free slot",m:"unused this scene",
+    h:"Empty in this scene. Because the pool is reused per scene, slots free here may be busy in another scene — only the busiest scene's peak counts against the 40 cap.",
+    a:"An empty seat for this particular show."},
+};
+
+/* ---------- build the bank grid (32 banks) ---------- */
+const bankgrid = document.getElementById('bankgrid');
+for(let i=0;i<32;i++){
+  const c=document.createElement('div');
+  c.className='bankcell';
+  let key,label;
+  if(i===0){c.classList.add('bk-home');key='bank-home';label='HOME';}
+  else if(i===31){c.classList.add('bk-music');key='bank-music';label='music';}
+  else{c.classList.add('bk-auto');key='bank-auto';label='auto';}
+  c.dataset.key=key;
+  c.innerHTML=`${i}<small>${label}</small>`;
+  bankgrid.appendChild(c);
+}
+
+/* ---------- OAM: per-scene model ----------
+   SOURCE OF TRUTH: tools/memory_check.py (SCENE_CONSUMERS); auto-synced by
+   tools/sync_scene_data.py on every `make`. Do NOT hand-edit between the markers. */
+/* SCENE_DATA:BEGIN */
+const SCENE_DATA = {
+  "budget": 40,
+  "pool": 32,
+  "worst_scene": "Playing",
+  "scenes": {
+    "Title": {
+      "peak": 0,
+      "consumers": []
+    },
+    "Overmap": {
+      "peak": 1,
+      "consumers": [
+        {
+          "label": "car",
+          "slots": 1
+        }
+      ]
+    },
+    "Hub": {
+      "peak": 1,
+      "consumers": [
+        {
+          "label": "dialog_arrow",
+          "slots": 1
+        }
+      ]
+    },
+    "Prerace": {
+      "peak": 0,
+      "consumers": []
+    },
+    "Playing": {
+      "peak": 32,
+      "consumers": [
+        {
+          "label": "player",
+          "slots": 4
+        },
+        {
+          "label": "projectiles",
+          "slots": 8
+        },
+        {
+          "label": "turrets",
+          "slots": 8
+        },
+        {
+          "label": "racers",
+          "slots": 8
+        },
+        {
+          "label": "patrol",
+          "slots": 4
+        }
+      ]
+    },
+    "Results": {
+      "peak": 0,
+      "consumers": []
+    },
+    "GameOver": {
+      "peak": 0,
+      "consumers": []
+    }
+  }
+};
+/* SCENE_DATA:END */
+
+const CONSUMER_COLOR={player:'#7ee787',projectiles:'#58a6ff',turrets:'#ff7b72',
+  racers:'#bc8cff',patrol:'#ffa657',car:'#39c5cf',dialog_arrow:'#f0883e'};
+const CONSUMER_LABEL={player:'Player',projectiles:'Bullets',turrets:'Turrets',
+  racers:'Racers',patrol:'Patrol',car:'Car',dialog_arrow:'Dialog arrow'};
+const FREE_COLOR='#30363d';
+
+const oamgrid=document.getElementById('oamgrid');
+const sceneReadout=document.getElementById('sceneReadout');
+const oamLegend=document.getElementById('oamLegend');
+const scenebtns=document.getElementById('scenebtns');
+
+function utilStatus(peak){const f=peak/SCENE_DATA.budget;return f>=1?'fail':f>=0.8?'warn':'pass';}
+
+function renderScene(name){
+  const sc=SCENE_DATA.scenes[name];
+  [...scenebtns.children].forEach(b=>b.classList.toggle('sel',b.dataset.scene===name));
+
+  /* legend */
+  oamLegend.innerHTML = sc.consumers.length
+    ? sc.consumers.map(c=>`<span><i style="background:${CONSUMER_COLOR[c.label]}"></i> ${CONSUMER_LABEL[c.label]||c.label} ×${c.slots}</span>`).join('')
+      + `<span><i style="background:${FREE_COLOR}"></i> Free ×${SCENE_DATA.budget-sc.peak}</span>`
+    : `<span><i style="background:${FREE_COLOR}"></i> No sprites — all ${SCENE_DATA.budget} slots free (text / background only)</span>`;
+
+  /* readout */
+  const st=utilStatus(sc.peak), pct=Math.round(sc.peak/SCENE_DATA.budget*100);
+  let cc='';
+  if(name===SCENE_DATA.worst_scene){
+    cc=` · cross-check vs pool MAX_SPRITES=${SCENE_DATA.pool}: `
+      +(sc.peak>SCENE_DATA.pool?'<span class="st-fail">FAIL</span>'
+        :sc.peak<SCENE_DATA.pool?'<span class="st-warn">WARN (over-provisioned)</span>'
+        :'<span class="st-pass">PASS (exact match)</span>');
+  }
+  sceneReadout.innerHTML=`<b>${name}</b> &nbsp; ${sc.peak} / ${SCENE_DATA.budget} slots (${pct}%) `
+    +`<span class="st-${st}">${st.toUpperCase()}</span>`
+    +(name===SCENE_DATA.worst_scene?' · busiest scene':'')+cc;
+
+  /* grid */
+  const fill=[];
+  sc.consumers.forEach(c=>{for(let k=0;k<c.slots;k++)fill.push(c.label);});
+  oamgrid.innerHTML='';
+  for(let i=0;i<SCENE_DATA.budget;i++){
+    const c=document.createElement('div');
+    c.className='oamcell';
+    const label=fill[i];
+    if(label){c.style.background=CONSUMER_COLOR[label];c.style.color='#0e1117';c.dataset.key='c-'+label;}
+    else{c.style.background=FREE_COLOR;c.style.color='#6e7681';c.dataset.key='c-free';}
+    c.textContent=i;
+    c.addEventListener('click',()=>show(c.dataset.key,c));
+    oamgrid.appendChild(c);
+  }
+}
+
+Object.keys(SCENE_DATA.scenes).forEach(name=>{
+  const b=document.createElement('button');
+  b.className='scenebtn'; b.dataset.scene=name;
+  b.innerHTML=`${name}<small>${SCENE_DATA.scenes[name].peak} slots</small>`;
+  b.addEventListener('click',()=>renderScene(name));
+  scenebtns.appendChild(b);
+});
+renderScene(SCENE_DATA.worst_scene);   /* default: the busiest scene (Playing) */
+
+/* ---------- click handling ---------- */
+const detail=document.getElementById('detail');
+let activeEl=null;
+function show(key,el){
+  const d=D[key];
+  if(!d)return;
+  if(activeEl)activeEl.classList.remove('active-el');
+  activeEl=el; el.classList.add('active-el');
+  detail.innerHTML=`
+    <h3>${d.t}</h3>
+    <div class="meta">${d.m}</div>
+    <p>${d.h}</p>
+    <div class="analogy"><b>🧠 Plain-English:</b> ${d.a}</div>`;
+  detail.scrollIntoView({behavior:'smooth',block:'nearest'});
+}
+/* OAM cells bind their own click in renderScene; bind everything else here. */
+document.querySelectorAll('[data-key]:not(.oamcell)').forEach(el=>{
+  el.addEventListener('click',()=>show(el.dataset.key,el));
+});
+</script>
+</body>
+</html>

--- a/tests/test_memory_check.py
+++ b/tests/test_memory_check.py
@@ -31,6 +31,21 @@ def _map_with_heap_e(addr):
     return f'     {addr:08X}  s__HEAP_E\n'
 
 
+def _config(max_sprites=28, proj=8, enemies=8, racers=2, patrols=0):
+    """Full OAM-relevant config.h. Playing peak = 4 + proj + enemies + racers*4 + patrols*4."""
+    return (
+        f'#define MAX_SPRITES {max_sprites}u\n'
+        f'#define MAX_PROJECTILES {proj}u\n'
+        f'#define MAX_ENEMIES {enemies}u\n'
+        f'#define MAX_ENEMY_RACERS {racers}u\n'
+        f'#define MAX_PATROLS {patrols}u\n'
+    )
+
+
+def _playing_peak(proj=8, enemies=8, racers=2, patrols=0):
+    return 4 + proj + enemies + racers * 4 + patrols * 4
+
+
 # ── WRAM tests ─────────────────────────────────────────────────────────────────
 
 class TestCheckWRAM(unittest.TestCase):
@@ -106,44 +121,136 @@ class TestCheckVRAM(unittest.TestCase):
             self.assertEqual(status, 'PASS')
 
 
-# ── OAM tests ──────────────────────────────────────────────────────────────────
+# ── Config-constant parsing ──────────────────────────────────────────────────────
+
+class TestParseConfig(unittest.TestCase):
+    def test_parses_u_suffix(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d, config_content='#define MAX_PROJECTILES 8u\n#define MAX_SPRITES 32\n')
+            consts = memory_check._parse_config_constants(d)
+            self.assertEqual(consts['MAX_PROJECTILES'], 8)
+            self.assertEqual(consts['MAX_SPRITES'], 32)
+
+    def test_missing_config_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, 'src'), exist_ok=True)
+            self.assertIsNone(memory_check._parse_config_constants(d))
+
+
+# ── Scene breakdown ──────────────────────────────────────────────────────────────
+
+class TestSceneBreakdown(unittest.TestCase):
+    def _consts(self, **kw):
+        defaults = dict(MAX_SPRITES=28, MAX_PROJECTILES=8, MAX_ENEMIES=8,
+                        MAX_ENEMY_RACERS=2, MAX_PATROLS=0)
+        defaults.update(kw)
+        return defaults
+
+    def test_playing_peak_sums_consumers(self):
+        scenes = memory_check._scene_breakdown(self._consts())
+        self.assertEqual(scenes['Playing']['peak'], _playing_peak())  # 4+8+8+8+0 = 28
+
+    def test_overmap_and_hub_are_one(self):
+        scenes = memory_check._scene_breakdown(self._consts())
+        self.assertEqual(scenes['Overmap']['peak'], 1)
+        self.assertEqual(scenes['Hub']['peak'], 1)
+
+    def test_text_scenes_are_zero(self):
+        scenes = memory_check._scene_breakdown(self._consts())
+        self.assertEqual(scenes['Title']['peak'], 0)
+        self.assertEqual(scenes['Prerace']['peak'], 0)
+        self.assertEqual(scenes['Results']['peak'], 0)
+        self.assertEqual(scenes['GameOver']['peak'], 0)  # blast reuses player slots
+
+    def test_playing_lists_five_consumers(self):
+        scenes = memory_check._scene_breakdown(self._consts())
+        labels = [c['label'] for c in scenes['Playing']['consumers']]
+        self.assertEqual(labels, ['player', 'projectiles', 'turrets', 'racers', 'patrol'])
+
+    def test_racers_use_four_slots_each(self):
+        scenes = memory_check._scene_breakdown(self._consts(MAX_ENEMY_RACERS=2))
+        racers = next(c for c in scenes['Playing']['consumers'] if c['label'] == 'racers')
+        self.assertEqual(racers['slots'], 8)
+
+
+# ── OAM check (scene-aware) ──────────────────────────────────────────────────────
 
 class TestCheckOAM(unittest.TestCase):
-    def _make_config(self, max_sprites):
-        return f'#define MAX_SPRITES  {max_sprites}\n'
-
-    def test_pass(self):
+    def test_busiest_scene_is_reported(self):
         with tempfile.TemporaryDirectory() as d:
-            make_repo(d, config_content=self._make_config(16))
-            used, status = memory_check._check_oam(d)
-            self.assertEqual(used, 19)
-            self.assertEqual(status, 'PASS')
+            make_repo(d, config_content=_config())
+            oam = memory_check._check_oam(d)
+            self.assertEqual(oam['worst_scene'], 'Playing')
+            self.assertEqual(oam['used'], _playing_peak())  # 28
+            self.assertEqual(oam['budget'], 40)
 
-    def test_warn(self):
+    def test_pass_when_pool_matches_and_under_80pct(self):
+        # peak 28, pool 28 -> crosscheck PASS, util 70% PASS
         with tempfile.TemporaryDirectory() as d:
-            make_repo(d, config_content=self._make_config(29))
-            used, status = memory_check._check_oam(d)
-            self.assertEqual(status, 'WARN')
+            make_repo(d, config_content=_config(max_sprites=28))
+            oam = memory_check._check_oam(d)
+            self.assertEqual(oam['crosscheck'], 'PASS')
+            self.assertEqual(oam['status'], 'PASS')
 
-    def test_fail(self):
+    def test_util_warn_at_80pct(self):
+        # peak 32, pool 32 -> crosscheck PASS but util 80% -> WARN
         with tempfile.TemporaryDirectory() as d:
-            make_repo(d, config_content=self._make_config(37))
-            used, status = memory_check._check_oam(d)
-            self.assertEqual(status, 'FAIL')
+            make_repo(d, config_content=_config(max_sprites=32, patrols=1))
+            oam = memory_check._check_oam(d)
+            self.assertEqual(oam['used'], 32)
+            self.assertEqual(oam['crosscheck'], 'PASS')
+            self.assertEqual(oam['status'], 'WARN')
 
-    def test_missing_define_returns_zero(self):
+    def test_crosscheck_fail_when_pool_too_small(self):
+        # peak 32, pool 20 -> FAIL
         with tempfile.TemporaryDirectory() as d:
-            make_repo(d, config_content='/* no MAX_SPRITES here */\n')
-            used, status = memory_check._check_oam(d)
-            self.assertEqual(used, 3)
-            self.assertEqual(status, 'PASS')
+            make_repo(d, config_content=_config(max_sprites=20, patrols=1))
+            oam = memory_check._check_oam(d)
+            self.assertEqual(oam['crosscheck'], 'FAIL')
+            self.assertEqual(oam['status'], 'FAIL')
+
+    def test_crosscheck_warn_when_over_provisioned(self):
+        # peak 28, pool 40 -> crosscheck WARN, util 70% PASS -> overall WARN
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d, config_content=_config(max_sprites=40))
+            oam = memory_check._check_oam(d)
+            self.assertEqual(oam['crosscheck'], 'WARN')
+            self.assertEqual(oam['status'], 'WARN')
+
+    def test_util_fail_over_hardware_cap(self):
+        # peak 44, pool 44 -> crosscheck PASS but util 110% -> FAIL
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d, config_content=_config(max_sprites=44, proj=20, patrols=1))
+            oam = memory_check._check_oam(d)
+            self.assertEqual(oam['used'], 44)
+            self.assertEqual(oam['status'], 'FAIL')
 
     def test_missing_config_file_returns_error(self):
         with tempfile.TemporaryDirectory() as d:
             os.makedirs(os.path.join(d, 'src'), exist_ok=True)
-            used, status = memory_check._check_oam(d)
-            self.assertIsNone(used)
-            self.assertEqual(status, 'ERROR')
+            oam = memory_check._check_oam(d)
+            self.assertIsNone(oam['used'])
+            self.assertEqual(oam['status'], 'ERROR')
+
+    def test_scenes_present_in_result(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d, config_content=_config())
+            oam = memory_check._check_oam(d)
+            self.assertIn('Playing', oam['scenes'])
+            self.assertIn('Overmap', oam['scenes'])
+
+
+# ── scenes_json emitter ──────────────────────────────────────────────────────────
+
+class TestScenesJson(unittest.TestCase):
+    def test_shape(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d, config_content=_config())
+            model = memory_check.scenes_json(d)
+            self.assertEqual(model['budget'], 40)
+            self.assertEqual(model['pool'], 28)
+            self.assertEqual(model['worst_scene'], 'Playing')
+            self.assertEqual(model['scenes']['Playing']['peak'], _playing_peak())
 
 
 # ── Integration / report tests ─────────────────────────────────────────────────
@@ -155,27 +262,26 @@ class TestCheck(unittest.TestCase):
                 d,
                 map_content=_map_with_heap_e(0xC23D),
                 tile_files={'track_tiles.c': 'const uint8_t t_count = 7u;\n'},
-                config_content='#define MAX_SPRITES 16\n',
+                config_content=_config(max_sprites=28),
             )
             result = memory_check.check(d)
             self.assertEqual(result['wram']['status'], 'PASS')
             self.assertEqual(result['vram']['status'], 'PASS')
             self.assertEqual(result['oam']['status'],  'PASS')
 
-    def test_report_contains_pass(self):
+    def test_report_contains_scene_breakdown(self):
         with tempfile.TemporaryDirectory() as d:
             make_repo(
                 d,
                 map_content=_map_with_heap_e(0xC23D),
                 tile_files={'track_tiles.c': 'const uint8_t t_count = 7u;\n'},
-                config_content='#define MAX_SPRITES 16\n',
+                config_content=_config(max_sprites=28),
             )
             result = memory_check.check(d)
             report = memory_check._format_report(result)
-            self.assertIn('PASS', report)
-            self.assertIn('WRAM', report)
-            self.assertIn('VRAM', report)
             self.assertIn('OAM', report)
+            self.assertIn('Playing', report)
+            self.assertIn('cross-check', report)
 
     def test_fail_exit_code(self):
         result = {

--- a/tests/test_sync_scene_data.py
+++ b/tests/test_sync_scene_data.py
@@ -1,0 +1,94 @@
+"""Tests for tools/sync_scene_data.py"""
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'tools'))
+import sync_scene_data
+
+
+CONFIG = (
+    '#define MAX_SPRITES 32u\n'
+    '#define MAX_PROJECTILES 8u\n'
+    '#define MAX_ENEMIES 8u\n'
+    '#define MAX_ENEMY_RACERS 2u\n'
+    '#define MAX_PATROLS 1u\n'
+)
+
+HTML = (
+    '<html><body><script>\n'
+    '/* SCENE_DATA:BEGIN */\n'
+    'const SCENE_DATA = {OLD};\n'
+    '/* SCENE_DATA:END */\n'
+    '</script></body></html>\n'
+)
+
+
+def make_repo(d, html=HTML, config=CONFIG):
+    os.makedirs(os.path.join(d, 'src'), exist_ok=True)
+    os.makedirs(os.path.join(d, 'docs'), exist_ok=True)
+    with open(os.path.join(d, 'src', 'config.h'), 'w') as f:
+        f.write(config)
+    with open(os.path.join(d, 'docs', 'memory-explained.html'), 'w', newline='') as f:
+        f.write(html)
+
+
+def read_html(d):
+    with open(os.path.join(d, 'docs', 'memory-explained.html'), 'r', newline='') as f:
+        return f.read()
+
+
+class TestSync(unittest.TestCase):
+    def test_writes_current_model(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d)
+            self.assertEqual(sync_scene_data.sync(d), 0)
+            out = read_html(d)
+            self.assertNotIn('{OLD}', out)
+            self.assertIn('"worst_scene": "Playing"', out)
+            self.assertIn('"peak": 32', out)
+            # markers preserved
+            self.assertIn(sync_scene_data.BEGIN, out)
+            self.assertIn(sync_scene_data.END, out)
+
+    def test_idempotent(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d)
+            sync_scene_data.sync(d)
+            first = read_html(d)
+            self.assertEqual(sync_scene_data.sync(d), 0)
+            self.assertEqual(read_html(d), first)
+
+    def test_check_detects_drift_then_clean(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d)
+            self.assertEqual(sync_scene_data.sync(d, check=True), 1)  # {OLD} is stale
+            sync_scene_data.sync(d)                                   # fix it
+            self.assertEqual(sync_scene_data.sync(d, check=True), 0)  # now in sync
+
+    def test_check_does_not_write(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d)
+            before = read_html(d)
+            sync_scene_data.sync(d, check=True)
+            self.assertEqual(read_html(d), before)
+
+    def test_missing_markers_errors(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d, html='<html><script>const SCENE_DATA={};</script></html>')
+            self.assertEqual(sync_scene_data.sync(d), 1)
+
+    def test_preserves_crlf(self):
+        with tempfile.TemporaryDirectory() as d:
+            make_repo(d, html=HTML.replace('\n', '\r\n'))
+            sync_scene_data.sync(d)
+            with open(os.path.join(d, 'docs', 'memory-explained.html'), 'rb') as f:
+                raw = f.read()
+            self.assertIn(b'\r\n', raw)
+            self.assertIsNone(re.search(rb'(?<!\r)\n', raw))  # no lone LF
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/memory_check.py
+++ b/tools/memory_check.py
@@ -5,30 +5,69 @@ memory_check.py — WRAM, VRAM, and OAM budget validator.
 Checks:
   1. WRAM: parses build/nuke-raider.map for s__HEAP_E symbol vs 8,192-byte budget.
   2. VRAM: scans src/*_tiles.c for *_count = N values vs 384-tile budget.
-  3. OAM:  parses src/config.h for MAX_SPRITES + 3 fixed slots vs 40-slot budget.
+  3. OAM:  scene-aware. Scenes (game states) are mutually exclusive and all share the
+           one recycling sprite pool, so the OAM that matters is the *busiest single
+           scene*, not the sum of every sprite in the game. The busiest scene (Playing)
+           is reported vs the 40-slot hardware cap, and cross-checked against the pool
+           size MAX_SPRITES (peak > pool => FAIL: pool too small; peak < pool => WARN:
+           over-provisioned). Per-consumer counts come from src/config.h constants.
 
 Exits 0 on PASS/WARN, 1 on FAIL.
 
 Usage:
     python3 tools/memory_check.py [repo_root]
+    python3 tools/memory_check.py --scenes-json [repo_root]   # emit the scene model
     or imported: memory_check.check(repo_root) -> dict
 """
 import glob
+import json
 import os
 import re
 import sys
 
 WRAM_BUDGET = 8192   # bytes
 VRAM_BUDGET = 384    # tiles (2 CGB banks × 192)
-OAM_BUDGET  = 40     # sprite slots
+OAM_BUDGET  = 40     # sprite slots (hardware cap — cannot change)
 
 WARN_FRAC = 0.80
 FAIL_FRAC = 1.00
 
 WRAM_BASE = 0xC000
 
-# Fixed OAM slots outside the sprite pool: player top + player bottom + dialog_arrow
-OAM_FIXED_SLOTS = 3
+# ── Per-scene OAM model ──────────────────────────────────────────────────────────
+# Each game state ("scene") lists the sprite consumers active while it is on screen.
+# A consumer is (label, source, slots_per_entity); slots = source * slots_per_entity,
+# where source is either an int literal or the name of a src/config.h #define.
+# Scenes are mutually exclusive and reuse the same pool (sprite_pool.c wipes + reallocs
+# on each scene's init), so live OAM = the busiest single scene, never the sum.
+#
+# Notes baked in from the code (keep in sync if these change):
+#   - player car = 4 OAM slots (4 get_sprite() calls in player_init).
+#   - explosions are slot-neutral: explosion_spawn() reuses the dying entity's slot
+#     (turret blast on its own slot; car blast on the player's slots), so GameOver and
+#     in-race explosions add nothing on top of the entities they replace.
+#   - overmap car = slot 0 only (overmap clears slots 1-39); hub = dialog_arrow (slot 4).
+#
+# This table is the SOURCE OF TRUTH for the HTML explainer's scene selector
+# (docs/memory-explained.html). Regenerate that file's embedded data with:
+#     python tools/memory_check.py --scenes-json
+SCENE_CONSUMERS = {
+    'Title':    [],
+    'Overmap':  [('car', 1, 1)],            # overmap car, slot 0
+    'Hub':      [('dialog_arrow', 1, 1)],   # DIALOG_ARROW_OAM_SLOT
+    'Prerace':  [],                         # text-only menu
+    'Playing':  [
+        ('player',      4,                  1),   # 4 get_sprite() in player_init
+        ('projectiles', 'MAX_PROJECTILES',  1),
+        ('turrets',     'MAX_ENEMIES',      1),
+        ('racers',      'MAX_ENEMY_RACERS', 4),   # enemy racers, 4 slots each
+        ('patrol',      'MAX_PATROLS',      4),   # patrol car, 4 slots each
+    ],
+    'Results':  [],                         # text-only
+    'GameOver': [],                         # car blast reuses player slots (slot-neutral)
+}
+
+_SEVERITY = {'PASS': 0, 'WARN': 1, 'FAIL': 2, 'ERROR': 3}
 
 
 def _status(used, budget):
@@ -38,6 +77,11 @@ def _status(used, budget):
     if frac >= WARN_FRAC:
         return 'WARN'
     return 'PASS'
+
+
+def _worst(*statuses):
+    """Return the most severe status (ERROR > FAIL > WARN > PASS)."""
+    return max(statuses, key=lambda s: _SEVERITY.get(s, 0))
 
 
 def _check_wram(repo_root):
@@ -68,18 +112,96 @@ def _check_vram(repo_root):
     return total, _status(total, VRAM_BUDGET)
 
 
-def _check_oam(repo_root):
-    """Parse src/config.h for MAX_SPRITES + fixed slots. Returns (slots, status)."""
+def _parse_config_constants(repo_root):
+    """Parse all `#define NAME <int>` from src/config.h. Returns dict or None if missing."""
     config_path = os.path.join(repo_root, 'src', 'config.h')
     try:
         with open(config_path) as f:
             content = f.read()
     except FileNotFoundError:
-        return None, 'ERROR'
-    m = re.search(r'#define\s+MAX_SPRITES\s+(\d+)', content)
-    pool_sprites = int(m.group(1)) if m else 0
-    total = pool_sprites + OAM_FIXED_SLOTS
-    return total, _status(total, OAM_BUDGET)
+        return None
+    consts = {}
+    for m in re.finditer(r'#define\s+(\w+)\s+(\d+)u?\b', content):
+        consts[m.group(1)] = int(m.group(2))
+    return consts
+
+
+def _resolve(source, consts):
+    """Resolve a consumer source: an int literal, or a config.h constant name (0 if absent)."""
+    if isinstance(source, int):
+        return source
+    return consts.get(source, 0)
+
+
+def _scene_breakdown(consts):
+    """Resolve SCENE_CONSUMERS against parsed constants.
+
+    Returns {scene: {'peak': int, 'consumers': [{'label', 'slots'}, ...]}}.
+    """
+    scenes = {}
+    for name, consumers in SCENE_CONSUMERS.items():
+        items = []
+        peak = 0
+        for label, source, per_entity in consumers:
+            slots = _resolve(source, consts) * per_entity
+            items.append({'label': label, 'slots': slots})
+            peak += slots
+        scenes[name] = {'peak': peak, 'consumers': items}
+    return scenes
+
+
+def _check_oam(repo_root):
+    """Scene-aware OAM check. Returns a dict (see module docstring).
+
+    Keys: used (busiest-scene peak, None on ERROR), budget, status, worst_scene,
+    scenes, pool (MAX_SPRITES), crosscheck, crosscheck_msg, util_status.
+    """
+    consts = _parse_config_constants(repo_root)
+    if consts is None:
+        return {
+            'used': None, 'budget': OAM_BUDGET, 'status': 'ERROR',
+            'worst_scene': None, 'scenes': {}, 'pool': None,
+            'crosscheck': 'ERROR', 'crosscheck_msg': 'src/config.h not found',
+            'util_status': 'ERROR',
+        }
+
+    scenes = _scene_breakdown(consts)
+    worst_scene = max(scenes, key=lambda s: scenes[s]['peak'])
+    peak = scenes[worst_scene]['peak']
+    pool = consts.get('MAX_SPRITES', 0)
+
+    util_status = _status(peak, OAM_BUDGET)
+
+    if peak > pool:
+        crosscheck = 'FAIL'
+        msg = f'busiest scene ({worst_scene}) needs {peak} slots but pool MAX_SPRITES={pool}'
+    elif peak < pool:
+        crosscheck = 'WARN'
+        msg = f'pool MAX_SPRITES={pool} over-provisioned for busiest scene ({worst_scene}={peak})'
+    else:
+        crosscheck = 'PASS'
+        msg = f'pool MAX_SPRITES={pool} matches busiest scene ({worst_scene})'
+
+    return {
+        'used': peak, 'budget': OAM_BUDGET,
+        'status': _worst(util_status, crosscheck),
+        'worst_scene': worst_scene, 'scenes': scenes, 'pool': pool,
+        'crosscheck': crosscheck, 'crosscheck_msg': msg,
+        'util_status': util_status,
+    }
+
+
+def scenes_json(repo_root='.'):
+    """Build the per-scene OAM model for external consumers (e.g. the HTML explainer)."""
+    consts = _parse_config_constants(repo_root) or {}
+    scenes = _scene_breakdown(consts)
+    worst_scene = max(scenes, key=lambda s: scenes[s]['peak']) if scenes else None
+    return {
+        'budget': OAM_BUDGET,
+        'pool': consts.get('MAX_SPRITES'),
+        'worst_scene': worst_scene,
+        'scenes': scenes,
+    }
 
 
 def overall_status(result):
@@ -103,10 +225,20 @@ def _format_report(result):
         '=== GB Memory Validation Report ===',
         f"WRAM:  {w['used']:,} / {w['budget']:,} bytes   ({pct(w['used'], w['budget'])}%)  {w['status']}",
         f"VRAM:  {v['used']} / {v['budget']} tiles   ({pct(v['used'], v['budget'])}%)  {v['status']}",
-        f"OAM:   {o['used']} / {o['budget']} sprites  ({pct(o['used'], o['budget'])}%)  {o['status']}",
-        '',
-        overall_status(result),
     ]
+    if o['used'] is None:
+        lines.append(f"OAM:   ERROR — {o['crosscheck_msg']}")
+    else:
+        lines.append(
+            f"OAM:   {o['used']} / {o['budget']} sprites  ({pct(o['used'], o['budget'])}%)  "
+            f"{o['status']}  [busiest scene: {o['worst_scene']}]"
+        )
+        lines.append(f"       cross-check vs pool: {o['crosscheck']} — {o['crosscheck_msg']}")
+        lines.append('       per-scene peak OAM:')
+        for name, sc in o['scenes'].items():
+            detail = ', '.join(f"{c['label']}={c['slots']}" for c in sc['consumers']) or '—'
+            lines.append(f"         {name:<9} {sc['peak']:>2} / {o['budget']}   ({detail})")
+    lines += ['', overall_status(result)]
     return '\n'.join(lines)
 
 
@@ -114,16 +246,21 @@ def check(repo_root='.'):
     """Run all three checks. Returns dict with 'wram', 'vram', 'oam' entries."""
     wram_used, wram_status = _check_wram(repo_root)
     vram_used, vram_status = _check_vram(repo_root)
-    oam_used,  oam_status  = _check_oam(repo_root)
+    oam = _check_oam(repo_root)
     return {
         'wram': {'used': wram_used, 'budget': WRAM_BUDGET, 'status': wram_status},
         'vram': {'used': vram_used, 'budget': VRAM_BUDGET, 'status': vram_status},
-        'oam':  {'used': oam_used,  'budget': OAM_BUDGET,  'status': oam_status},
+        'oam':  oam,
     }
 
 
 def main():
-    repo_root = sys.argv[1] if len(sys.argv) > 1 else '.'
+    args = sys.argv[1:]
+    if args and args[0] == '--scenes-json':
+        repo_root = args[1] if len(args) > 1 else '.'
+        print(json.dumps(scenes_json(repo_root), indent=2))
+        sys.exit(0)
+    repo_root = args[0] if args else '.'
     result = check(repo_root)
     print(_format_report(result))
     sys.exit(1 if overall_status(result) == 'FAIL' else 0)

--- a/tools/sync_scene_data.py
+++ b/tools/sync_scene_data.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Keep docs/memory-explained.html's SCENE_DATA block in sync with src/config.h.
+
+The HTML explainer embeds `const SCENE_DATA = {...}` between marker comments. This
+regenerates that block from memory_check.scenes_json(), so the per-scene OAM model
+in the explainer never drifts from the build's view of config.h.
+
+Idempotent: writing the same model twice produces identical bytes (no git churn).
+Existing line endings (LF or CRLF) are preserved.
+
+Usage:
+    python tools/sync_scene_data.py [repo_root]            # write
+    python tools/sync_scene_data.py --check [repo_root]    # exit 1 if out of sync
+    or imported: sync_scene_data.sync(repo_root, check=False) -> int (0 ok, 1 problem)
+"""
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import memory_check
+
+BEGIN = '/* SCENE_DATA:BEGIN */'
+END = '/* SCENE_DATA:END */'
+HTML_REL = os.path.join('docs', 'memory-explained.html')
+
+
+def _block(repo_root, nl):
+    """Build the replacement block (markers + JS literal) using newline `nl`."""
+    model = memory_check.scenes_json(repo_root)
+    raw = BEGIN + '\n' + 'const SCENE_DATA = ' + json.dumps(model, indent=2) + ';\n' + END
+    return raw.replace('\n', nl)
+
+
+def sync(repo_root='.', check=False):
+    """Regenerate (or, with check=True, validate) the HTML SCENE_DATA block.
+
+    Returns 0 on success / already-in-sync, 1 on missing markers or (check mode) drift.
+    """
+    path = os.path.join(repo_root, HTML_REL)
+    with open(path, 'r', encoding='utf-8', newline='') as f:
+        content = f.read()
+
+    if BEGIN not in content or END not in content:
+        print(f"sync_scene_data: markers {BEGIN} .. {END} not found in {HTML_REL}", file=sys.stderr)
+        return 1
+
+    nl = '\r\n' if '\r\n' in content else '\n'
+    pat = re.compile(re.escape(BEGIN) + '.*?' + re.escape(END), re.S)
+    new = pat.sub(lambda m: _block(repo_root, nl), content, count=1)
+
+    if new == content:
+        return 0
+    if check:
+        print(f"sync_scene_data: {HTML_REL} OAM scene data is stale — "
+              f"run `make` or `python tools/sync_scene_data.py`", file=sys.stderr)
+        return 1
+
+    with open(path, 'w', encoding='utf-8', newline='') as f:
+        f.write(new)
+    print(f"sync_scene_data: updated {HTML_REL}")
+    return 0
+
+
+def main():
+    args = sys.argv[1:]
+    check = '--check' in args
+    args = [a for a in args if a != '--check']
+    repo_root = args[0] if args else '.'
+    sys.exit(sync(repo_root, check=check))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What & why

The OAM budget check reported a single misleading number — `MAX_SPRITES (32) + 3 fixed = 35/40` — that summed sprite consumers across **mutually-exclusive game scenes**. In reality every scene wipes and reuses one shared sprite pool (`sprite_pool_init()` runs on each scene''s init), so the only number that matters is the **busiest single scene**.

## Changes (tooling + docs only — no `.c/.h`, ROM unchanged)

- **`tools/memory_check.py`** — scene-aware OAM:
  - Per-scene peak from a `SCENE_CONSUMERS` table; counts parsed from `config.h`.
  - Reports the busiest scene (Playing = **32/40, 80%, WARN**) vs the 40 hardware cap.
  - **Cross-check vs `MAX_SPRITES`**: `peak > pool` → **FAIL** (pool too small for declared consumers), `peak < pool` → WARN (over-provisioned), `==` → clean. Catches silent over-subscription from a future `config.h` edit.
  - New `--scenes-json` emitter; report prints a per-scene breakdown.
- **`docs/memory-explained.html`** — interactive ROM-memory explainer; OAM section now has a **scene selector** that repaints the 40-slot grid per scene with a peak/status/cross-check readout.
- **`tools/sync_scene_data.py`** (new) — regenerates the HTML''s `SCENE_DATA` block from `config.h`. Idempotent (no build churn), preserves line endings, has a `--check` drift mode.
- **`Makefile`** — `make` runs `sync-docs` (proven zero churn on rebuild); `test-tools` now also runs `test_memory_check` + `test_sync_scene_data`.
- **`README.md`** — pointer to the explainer.

## Verification

- `make clean && make` → exit 0; `memory-check` → `OAM 32/40 (80%) WARN [busiest scene: Playing]`, cross-check PASS, exit 0.
- New/updated tests: **36 pass** (`test_memory_check`, `test_sync_scene_data`). Sync proven idempotent + `--check` clean.
- Rebuild produces zero working-tree churn on the HTML.
- Pre-existing `test-tools` failures (`test_tmx_to_c`, `test_balancer` [needs `termios`], `test_bank_post_build`) are byte-identical to `master` — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)