### PR TITLE
fix: run pre-commit build gate via PowerShell, not bash

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,8 +7,8 @@
           {
             "type": "command",
             "if": "Bash(git commit*)",
-            "command": "bash -c \"ROOT=$(git rev-parse --show-toplevel) && make -C \\\"$ROOT\\\" clean && make -C \\\"$ROOT\\\"\"",
-            "timeout": 120,
+            "command": "powershell -NoProfile -Command \"$r = git rev-parse --show-toplevel; $env:GBDK_HOME='C:/gbdk'; $env:PATH='C:\\Program Files\\Git\\bin;C:\\Program Files\\Git\\usr\\bin;' + $env:PATH; Set-Location $r; make clean; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; make; exit $LASTEXITCODE\"",
+            "timeout": 300,
             "statusMessage": "Pre-commit build gate: clean build..."
           }
         ]

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -133,7 +133,11 @@
       "PowerShell($noi = Get-Content build/nuke-raider.noi; $banks = @{}; foreach \\($line in $noi\\) { if \\($line -match '^DEF\\\\s+\\\\S'\\) {} }; Write-Output \"=== Sample of .noi \\(DEF lines with addresses\\) ===\"; $noi | Select-String '^DEF' | Select-Object -First 5; Write-Output \"=== Searching map for Area/bank summary ===\"; Select-String -Path build/nuke-raider.map -Pattern '_CODE_|ROM bank|_HOME|HEADER' | Select-Object -First 30 | ForEach-Object { $_.Line })",
       "PowerShell(Start-Process \"docs/memory-explained.html\")",
       "PowerShell(Copy-Item *)",
-      "PowerShell(python -m pytest tests/test_memory_check.py -q 2>&1 | Select-Object -Last 15)"
+      "PowerShell(python -m pytest tests/test_memory_check.py -q 2>&1 | Select-Object -Last 15)",
+      "PowerShell(git fetch *)",
+      "PowerShell(gh pr list --state open --json number,title,headRefName)",
+      "PowerShell(gh issue list --state open --limit 40 --json number,title,labels | ConvertFrom-Json | Sort-Object number | ForEach-Object { \"#$\\($_.number\\) [$\\($_.labels.name -join ','\\)] $\\($_.title\\)\" })",
+      "PowerShell(gh pr list --state open --limit 20 --json number,title,headRefName | ConvertFrom-Json | ForEach-Object { \"#$\\($_.number\\) $\\($_.title\\) \\($\\($_.headRefName\\)\\)\" })"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Problem

The pre-commit build-gate hook in `.claude/settings.json` blocked **every** `git commit` made through the Bash tool:

```
make: the '-C' option requires a non-empty string argument
```

Root cause: the hook command was `bash -c "ROOT=$(git rev-parse --show-toplevel) && make -C \"$ROOT\" clean && make -C \"$ROOT\""`. It relied on **bash-level** `$ROOT` expansion, but on Windows the harness runs hook commands through PowerShell, which expanded `$ROOT` to empty *before* bash ran — producing `make -C ""`. The gate has been non-functional and routinely bypassed (documented in `CLAUDE.local.md`).

## Fix

Rewrite the gate as `powershell -NoProfile -Command "..."` — the same proven pattern as the working Emulicious window-reset hook in `settings.local.json`. The PowerShell script:

- captures the repo root via `git rev-parse --show-toplevel` (works from worktrees too),
- sets `GBDK_HOME` + the Git `bin`/`usr\bin` PATH the Makefile needs,
- runs `make clean` then `make`,
- propagates the exit code, so a **failed build still blocks the commit** (gate behavior preserved).

Timeout bumped 120 → 300 s to accommodate a full clean build.

## Verification

- Ran the exact PowerShell command end-to-end in a worktree: clean build succeeded, `BUILD_EXIT=0` (commit allowed; a non-zero build exit blocks the commit).
- `.claude/settings.json` validated as well-formed JSON.

## Notes

- Hooks do not hot-reload mid-session, so this takes effect in new sessions.
- ROM is unaffected (config-only change); no smoketest applicable.